### PR TITLE
Swallowed paragraph checker

### DIFF
--- a/MAGSBS/quality_assurance/markdown.py
+++ b/MAGSBS/quality_assurance/markdown.py
@@ -320,7 +320,9 @@ class HeadingsUseEitherUnderliningOrHashes(Mistake):
                         lnum=heading.get_line_number())
 
 class ParagraphMayNotEndOnBackslash(Mistake):
-    r"""If a paragraph ends on a backslash, the next line will be treated as being part of the paragraph. Therefore the intentional paragraph break is lost. Example:
+    r"""If a paragraph ends on a backslash, the next line will be treated as
+    being part of the paragraph. Therefore the intentional paragraph break is
+    lost. Example:
 
         ~~~~
         some text\
@@ -335,11 +337,11 @@ class ParagraphMayNotEndOnBackslash(Mistake):
 
     def worker(self, *args):
         content, file_name = args
-        for start_line, paragraph in content:
-            if paragraph and paragraph[-1] == '\\':
-                self.error(("Wenn ein Absatz mit einem \\ umgebrochen wird, so "
-                    "wird die nächste (leere) Zeile dem vorigen Absatz "
-                    "zugeordnet. Der Absatz geht verloren und in der Folge wird "
-                    "das folgende Element falsch formatiert."),
+        for start_line, paragraph in content.items():
+            if paragraph and paragraph[-1].endswith('\\'):
+                return self.error(("Wenn ein Absatz mit einem \\ umgebrochen "
+                    "wird, so wird die nächste (leere) Zeile dem vorigen "
+                    "Absatz zugeordnet. Der Absatz geht verloren und in der "
+                    "Folge wird das folgende Element falsch formatiert."),
                     lnum=start_line + len(paragraph), path=file_name)
 

--- a/MAGSBS/quality_assurance/meta.py
+++ b/MAGSBS/quality_assurance/meta.py
@@ -18,10 +18,12 @@ class MistakeType(enum.Enum):
     """The mistake type determines the arguments and the environment in which to
     run the tests.
 
-Note for this table: from datastructures import Heading as H
+Shortcuts for this table: par == paragraph, h == datastructures.Heading
 
 type                parameters      Explanation
-full_file           (content, name) applied to a whole file
+full_file           (content, name) content: dict mapping from line number to
+                                    par, par is a list of lines; name is the
+                                    path to the file
 oneliner            (num, line)     applied to line, starting num = 1
 need_headings       [H(), ...]      applied to all headings
 need_headings_dir   {path : [H(),   applied to all headings in a directory

--- a/tests/test_quality_assurance/README.md
+++ b/tests/test_quality_assurance/README.md
@@ -1,0 +1,9 @@
+quality assurance &mdash; Mistkerl
+==================================
+
+Normally it is advised for this project to have one test*.py per real *.py file.
+For the checkers there should be one test*.py for each checker, named 
+`test_<name of checker>`.
+
+The `__init__.py` file is necessary so that the unit test discovery find all the
+tests in this subdirectory.

--- a/tests/test_quality_assurance/test_ParagraphMayNotEndOnBackslash.py
+++ b/tests/test_quality_assurance/test_ParagraphMayNotEndOnBackslash.py
@@ -1,0 +1,19 @@
+#pylint: disable=too-many-public-methods,import-error,too-few-public-methods,missing-docstring,unused-variable
+import unittest
+import MAGSBS.quality_assurance as qa
+import MAGSBS.quality_assurance.markdown as ma
+
+class test_ParagraphMayNotEndOnBackslash(unittest.TestCase):
+    def test_normal_paragraphs_are_recognized(self):
+        content1 = {1 : ['line1', 'line2', 'line3']}
+        content2 = {1 : ['line1', 'line2', 'line3',], 8 : ['foo', 'bar']}
+        self.assertEqual(ma.ParagraphMayNotEndOnBackslash().worker(content1,
+            'dummy'), None)
+        self.assertEqual(ma.ParagraphMayNotEndOnBackslash().worker(content2,
+            'dummy'), None)
+
+    def test_that_error_case_is_correctly_identified(self):
+        content = {1:['a','b','c\\'], 5:['dummy']}
+        err_obj = ma.ParagraphMayNotEndOnBackslash().worker(content, 'dummy')
+        self.assertTrue(isinstance(err_obj, qa.meta.error_message))
+


### PR DESCRIPTION
MarkDown paragraphs MUST NOT end on \, otherwise the next blank line, normally denoting the begin of a new paragraph, will be swallowed by the previous paragraph and hence the formatting of the next paragraph is broken.