### PR TITLE
Gettext implementation - first version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.pyc
+*.mo
 build
 cli/build
 dist

--- a/MAGSBS/config.py
+++ b/MAGSBS/config.py
@@ -53,6 +53,8 @@ LANG = locale.getdefaultlocale()[0][:2] # default language of the system
 # get locale subdirectory of the matuc main directory
 CONFIG_DIR = os.path.join(dirname(dirname(os.path.realpath(__file__))), "locale")
 
+print("test XXX")
+
 # TODO: generation of mo files during setup - they should be entered to the
 # space, where matuc is installed. It should create the structure
 # locale/cs/LC_MESSAGE/messages.mo during the matuc installation -
@@ -74,8 +76,12 @@ def create_mo_files():
         lib_dir = os.path.join(dirname(sys.executable), "Tools", "i18n", "msgfmt.py")
         # create and call the msgfmt
         # TODO: test this on POSIX operating system
-        msgfmt_cmd = r'python {} -o "{}" "{}"'.format(lib_dir, os.path.join(
-            file_dir, "messages.mo"), os.path.join(file_dir, "messages.po"))
+        arguments = '-o "{}" "{}"'.format(os.path.join(file_dir, "messages.mo"),
+            os.path.join(file_dir, "messages.po"))
+        if os.name == "nt":
+            msgfmt_cmd = "python {} {}".format(lib_dir, arguments)
+        if os.name == "posix":
+            msgfmt_cmd = "msgfmt {}".format(arguments)
         subprocess.call(msgfmt_cmd, shell=True)
 
 create_mo_files() # should be removed after the .mo files are correctly

--- a/MAGSBS/config.py
+++ b/MAGSBS/config.py
@@ -15,11 +15,14 @@ from distutils.version import StrictVersion
 import os
 import re
 import sys
+import gettext
+import locale
 import xml.etree.ElementTree as ET
 from xml.dom import minidom
 from . import common
 from .errors import ConfigurationError
 from . import roman
+from os.path import dirname
 
 VERSION = StrictVersion('0.7.0')
 
@@ -40,6 +43,39 @@ PAGENUMBERING_PATTERN = re.compile(r'''
         (\d+|%s)\s*- # arabic or roman numbers
         ''' % ('|'.join(PAGENUMBERINGTOKENS), roman_number_regex),
         re.VERBOSE)
+
+
+# importing language versions
+# TODO: this could be a function that is called during initialization
+LANG = locale.getdefaultlocale()[0][:2] # detects the language of the system
+CONFIG_DIR = dirname(dirname(os.path.realpath(__file__))) + "/locale" # get the main directory of the system
+
+# generate mo files (somewhere in the user's space)
+# TODO: generation of mo files
+"""
+Code from: https://stackoverflow.com/questions/34070103/how-to-compile-po-gettext-translations-in-setup-py-python-script
+PO_FILES = 'translations/locale/*/LC_MESSAGES/app_name.po'
+
+def create_mo_files():
+    mo_files = []
+    prefix = 'app_name'
+
+    for po_path in glob.glob(str(pathlib.Path(prefix) / PO_FILES)):
+        mo = pathlib.Path(po_path.replace('.po', '.mo'))
+
+        subprocess.run(['msgfmt', '-o', str(mo), po_path], check=True)
+        mo_files.append(str(mo.relative_to(prefix)))
+"""
+
+# load the mo file
+# TODO load generated mo files instead of pre-generated one
+try:
+    trans = gettext.translation("messages", localedir=CONFIG_DIR , languages=[LANG])
+    _ = trans.gettext
+except IOError:
+    # in case language file is not found
+    _ = lambda s: s
+
 
 def get_semester():
     """Guess the current semester from the current time. Semesters are based on

--- a/MAGSBS/config.py
+++ b/MAGSBS/config.py
@@ -51,9 +51,7 @@ PAGENUMBERING_PATTERN = re.compile(r'''
 # during initialization
 LANG = locale.getdefaultlocale()[0][:2] # default language of the system
 # get locale subdirectory of the matuc main directory
-CONFIG_DIR = os.path.join(dirname(dirname(os.path.realpath(__file__))), "locale")
-
-print("test XXX")
+CONFIG_DIR = os.path.join(dirname(dirname(os.path.realpath(__file__))), "po")
 
 # TODO: generation of mo files during setup - they should be entered to the
 # space, where matuc is installed. It should create the structure
@@ -84,7 +82,7 @@ def create_mo_files():
             msgfmt_cmd = "msgfmt {}".format(arguments)
         subprocess.call(msgfmt_cmd, shell=True)
 
-create_mo_files() # should be removed after the .mo files are correctly
+# create_mo_files() # should be removed after the .mo files are correctly
                   # installed into users space
 
 # load .mo files

--- a/MAGSBS/config.py
+++ b/MAGSBS/config.py
@@ -46,52 +46,18 @@ PAGENUMBERING_PATTERN = re.compile(r'''
 
 
 # Importing language versions
-
-# TODO: this (and loading .mo files) should be a function that is called
-# during initialization
-LANG = locale.getdefaultlocale()[0][:2] # default language of the system
+LANG = locale.getdefaultlocale()[0][:2]  # default system's language
 # get locale subdirectory of the matuc main directory
-CONFIG_DIR = os.path.join(dirname(dirname(os.path.realpath(__file__))), "po")
+CONFIG_DIR = os.path.join(dirname(dirname(os.path.realpath(__file__))),
+                          "locale")
 
-# TODO: generation of mo files during setup - they should be entered to the
-# space, where matuc is installed. It should create the structure
-# locale/cs/LC_MESSAGE/messages.mo during the matuc installation -
-# it should be implemented somewhere in the setup.py
-
-# This function generates .mo files from .po files for every language
-# It uses msgfmt script from gettext library.
-# Please note, that this should be called here for testing purposes only,
-# because .mo files are not installed in the current version of the matuc
-import subprocess
-
-def create_mo_files():
-    localedir = CONFIG_DIR
-    # get all languages
-    languages = next(os.walk(localedir))[1]
-    for lang in languages:
-        # set directories
-        file_dir = os.path.join(CONFIG_DIR, lang, "LC_MESSAGES")
-        lib_dir = os.path.join(dirname(sys.executable), "Tools", "i18n", "msgfmt.py")
-        # create and call the msgfmt
-        # TODO: test this on POSIX operating system
-        arguments = '-o "{}" "{}"'.format(os.path.join(file_dir, "messages.mo"),
-            os.path.join(file_dir, "messages.po"))
-        if os.name == "nt":
-            msgfmt_cmd = "python {} {}".format(lib_dir, arguments)
-        if os.name == "posix":
-            msgfmt_cmd = "msgfmt {}".format(arguments)
-        subprocess.call(msgfmt_cmd, shell=True)
-
-# create_mo_files() # should be removed after the .mo files are correctly
-                  # installed into users space
-
-# load .mo files
 try:
-    trans = gettext.translation("messages", localedir=CONFIG_DIR, languages=[LANG])
-    _ = trans.gettext
+    trans = gettext.translation("messages", localedir=CONFIG_DIR,
+                                languages=[LANG])
+    _ = trans.gettext  # load .mo files
 except IOError:
-    # if the file with traslations is not found, original strings are user
-    _ = lambda s: s
+    # if the file with translation is not found, original strings are used
+    def _(s): return s
 
 
 def get_semester():

--- a/MAGSBS/quality_assurance/all_formats.py
+++ b/MAGSBS/quality_assurance/all_formats.py
@@ -4,6 +4,7 @@ import os
 from xml.etree import ElementTree as ET
 from .. import config, common
 from .meta import MistakeType, Mistake, OnelinerMistake
+from ..config import _
 
 class ConfigurationValuesAreAllSet(Mistake):
     """Check whether all configuration options have been set."""
@@ -19,9 +20,9 @@ class ConfigurationValuesAreAllSet(Mistake):
             return node.tag[node.tag.find('}') + 1 :]
         for node in root.getchildren():
             if not node.text or 'unknown' in node.text.lower():
-                return self.error("Fehler in der Konfiguration: Der Wert {} ist "
+                return self.error(_("Fehler in der Konfiguration: Der Wert {} ist "
                     "nicht gesetzt, wodurch die Kopfdaten in den HTML-Dateien "
-                    "nicht erzeugt werden können.".format(get_tag(node)),
+                    "nicht erzeugt werden können.").format(get_tag(node)),
                     config.get_lnum_of_tag(args[0], node.tag), args[0])
 
 class BrokenUmlautsFromPDFFiles(OnelinerMistake):
@@ -42,10 +43,10 @@ class BrokenUmlautsFromPDFFiles(OnelinerMistake):
     def check(self, num, line):
         for seq in self.garbled:
             if seq in line:
-                return super().error("Es wurden inkorrekt dargestellte Umlaute "
+                return super().error(_("Es wurden inkorrekt dargestellte Umlaute "
                         "gefunden. Dies geschieht oft, wenn Text aus "
                         "PDF-Dateien kopiert wird. Das macht den Text "
-                        "allerdings schwer leserlich.", num)
+                        "allerdings schwer leserlich."), num)
 
 class OnlyCorrectDirectoriesFound(Mistake):
     mistake_type = MistakeType.lecture_root
@@ -57,7 +58,6 @@ class OnlyCorrectDirectoriesFound(Mistake):
                     '.lecture_meta')):
                 continue
             if not common.is_valid_file(file):
-                return self.error("Die Datei \"{}\" ist falsch benannt und folgt "
+                return self.error(_("Die Datei \"{}\" ist falsch benannt und folgt "
                     "nicht den Namenskonventionen. Dies führt zu einer falschen "
-                    "Verwendung der Datei.".format(file), path=root)
-
+                    "Verwendung der Datei.").format(file), path=root)

--- a/MAGSBS/quality_assurance/latex.py
+++ b/MAGSBS/quality_assurance/latex.py
@@ -5,7 +5,7 @@ embedded there as well."""
 
 import re
 from .meta import FormulaMistake, OnelinerMistake, Mistake, MistakeType
-
+from ..config import _
 
 class CasesSqueezedOnOneLine(FormulaMistake):
     r"""\begin{cases} ... lots of stuff \end{cases} is hard to read. There
@@ -19,9 +19,9 @@ class CasesSqueezedOnOneLine(FormulaMistake):
             if '\n' in formula:
                 continue
             if r'\begin{cases}' in formula and r'\end{cases}' in formula:
-                return self.error("Die LaTeX-Umgebung zur Fallunterscheidung "
+                return self.error(_("Die LaTeX-Umgebung zur Fallunterscheidung "
                     "(cases) sollte Zeilenumbrüche an den passenden Stellen "
-                    "enthalten, um die Lesbarkeit zu gewährleisten.",
+                    "enthalten, um die Lesbarkeit zu gewährleisten."),
                     lnum=pos[0], pos=pos[1])
 
 
@@ -37,10 +37,10 @@ class LaTeXMatricesShouldBeConstructeedUsingPmatrix(FormulaMistake):
     def worker(self, *args):
         for (line, pos), formula in args[0].items():
             if self.PATTERN.search(formula):
-                return self.error("Matrizen sollten, damit sie einfach lesbar "
+                return self.error(_("Matrizen sollten, damit sie einfach lesbar "
                     "sind, nicht mit \\left\\(..., sondern einfach mit "
                     "\\begin{pmatrix}...  erzeugt werden. Dabei werden auch "
-                    "Klammern automatisch gesetzt und es ist kürzer.",
+                    "Klammern automatisch gesetzt und es ist kürzer."),
                     lnum=line, pos=pos)
 
 class LaTeXMatricesShouldHaveLineBreaks(FormulaMistake):
@@ -52,8 +52,8 @@ class LaTeXMatricesShouldHaveLineBreaks(FormulaMistake):
     def worker(self, *args):
         for (line, pos), formula in args[0].items():
             if self.pattern.search(formula):
-                return self.error("Jede Zeile einer Matrix oder Tabelle sollte"
-                    " zur besseren Lesbarkeit auf eine eigene Zeile gesetzt werden.",
+                return self.error(_("Jede Zeile einer Matrix oder Tabelle sollte"
+                    " zur besseren Lesbarkeit auf eine eigene Zeile gesetzt werden."),
                     lnum=line, pos=pos)
 
 
@@ -70,10 +70,10 @@ class LaTeXUmlautsUsed(OnelinerMistake):
         lower = line.lower()
         for token in self.umlauts:
             if token in lower:
-                return super().error("Anstatt einen Umlaut zu schreiben, wurde "
+                return super().error(_("Anstatt einen Umlaut zu schreiben, wurde "
                     "eine LaTeX-Kontrollsequenz verwendet. Das ist schwer "
                     "leserlich und kann außerdem einfach durch setzen des "
-                    "Zeichensatzes umgangen werden.", num)
+                    "Zeichensatzes umgangen werden."), num)
 
 
 class DisplayMathShouldNotBeUsedWithinAParagraph(OnelinerMistake):
@@ -88,11 +88,11 @@ class DisplayMathShouldNotBeUsedWithinAParagraph(OnelinerMistake):
         if line:
             matched = self._pattern.search(line)
             if matched:
-                return self.error("Formeln in einem Absatz (umgeben von Text), "
+                return self.error(_("Formeln in einem Absatz (umgeben von Text), "
                     "müssen mit einfachen $-Zeichen gesetzt werden, da sich die "
                     "Formeln sonst in der Ausgabe nicht in den Text integrieren. "
                     "$$ (display math) sollte für einzeln stehende Formeln "
-                    "verwendet werden.", num, pos=matched.span()[1])
+                    "verwendet werden."), num, pos=matched.span()[1])
 
 class SpacingInFormulaShouldBeDoneWithQuad(FormulaMistake):
     r"""Some people tend to use `\ \ \ \ ...` to format a bigger space within an equation. This is hard to read
@@ -100,8 +100,8 @@ class SpacingInFormulaShouldBeDoneWithQuad(FormulaMistake):
     def worker(self, *args):
         for (line, pos), formula in args[0].items():
             if r'\ \ \ \ ' in formula:
-                return self.error("Leerräume in Formeln sollten mit \\quad oder \\qquad "
-                    "gekennzeichnet werden, da sie sonst mit Sprachausgabe schwer lesbar sind.",
+                return self.error(_("Leerräume in Formeln sollten mit \\quad oder \\qquad "
+                    "gekennzeichnet werden, da sie sonst mit Sprachausgabe schwer lesbar sind."),
                     lnum=line, pos=pos)
 
 class UseProperCommandsForMathOperatorsAndFunctions(FormulaMistake):
@@ -122,10 +122,10 @@ class UseProperCommandsForMathOperatorsAndFunctions(FormulaMistake):
                 if not match:
                     continue
                 if not has_backslash(formula, match.span()[0]):
-                    return self.error("{0} sollte in LaTeX-Formeln grundsätzlich als "
+                    return self.error(_("{0} sollte in LaTeX-Formeln grundsätzlich als "
                         "Befehl gesetzt werden, d.h. mittels \\{0}. Nur so wird es in "
                         "der Ausgabe korrekt formatiert und ist gleichzeitig gut "
-                        "lesbar.".format(mathop.pattern.replace('\\b', '')), lnum=line, pos=pos)
+                        "lesbar.").format(mathop.pattern.replace('\\b', '')), lnum=line, pos=pos)
 
 
 class FormulasSpanningAParagraphShouldBeDisplayMath(Mistake):
@@ -143,7 +143,7 @@ class FormulasSpanningAParagraphShouldBeDisplayMath(Mistake):
             if self.beginning.search(para[0]) and self.ending.search(para[-1]):
                 # count dollars to be sure that it's just one math env
                 if sum(l.count('$') for l in para) < 3:
-                    return self.error(("Eine Formel, die einzeln in einem Absatz "
+                    return self.error(_("Eine Formel, die einzeln in einem Absatz "
                         "steht, wurde als eingebettete Formel mit einfachen $ gesetzt. "
                         "Stattdessen sollten doppelte Dollarzeichen verwendet werden,"
                         " da dies verhindert, dass LaTeX die Formel auf Zeilenhöhe "

--- a/MAGSBS/quality_assurance/markdown.py
+++ b/MAGSBS/quality_assurance/markdown.py
@@ -1,4 +1,3 @@
-# vim: set expandtab sts=4 ts=4 sw=4 tw=0 ft=python:
 # This is free software, licensed under the LGPL v3. See the file "COPYING" for
 # details.
 #
@@ -10,13 +9,14 @@ import os
 import re
 from .meta import Mistake, MistakeType, OnelinerMistake
 from .. import config, common
+from ..config import _
 MetaInfo = config.MetaInfo
 
 class PageNumberIsParagraph(Mistake):
     """Check whether all page numbers are on a paragraph on their own."""
     def __init__(self):
         super().__init__()
-        self._error_text = ("Jede Seitenzahl muss in der Zeile darueber oder darunter eine Leerzeile haben, "
+        self._error_text = _("Jede Seitenzahl muss in der Zeile darueber oder darunter eine Leerzeile haben, "
             "das heißt sie muss in einem eigenen Absatz stehen.")
         self.pattern = re.compile(r'^\|\|\s*' + config.PAGENUMBERING_PATTERN.pattern)
 
@@ -45,9 +45,9 @@ class LevelOneHeading(Mistake):
             for heading in headings:
                 if heading.get_level() == 1:
                     if found_h1:
-                        return self.error("In diesem Verzeichnis gibt es mehr als eine Überschrift der Ebene 1. Dies ist nicht erlaubt. "
+                        return self.error(_("In diesem Verzeichnis gibt es mehr als eine Überschrift der Ebene 1. Dies ist nicht erlaubt. "
                             "Beispielsweise hat jeder Foliensatz nur eine Hauptüberschrift und auch ein Kapitel wird nur mit einer "
-                            "Überschrift bezeichnet.")
+                            "Überschrift bezeichnet."))
                     else:
                         found_h1 = True
 
@@ -85,7 +85,7 @@ class ItemizeIsParagraph(Mistake):
                 elif is_item(line):
                     # itemize encountered and first line was no itemize line?
                     if item_encountered:
-                        err_message = ("Eine Aufzählung muss in einem eigenen Absatz stehen, d. h. es muss davor "
+                        err_message = _("Eine Aufzählung muss in einem eigenen Absatz stehen, d. h. es muss davor "
                             "und danach eine Leerzeile sein.")
                         return self.error(err_message, start_line+lnum)
                     else:
@@ -104,7 +104,7 @@ indexing of page numbers."""
     def worker(self, *args):
         for pnum in args[0]:
             if not pnum.identifier in self.page_identifiers:
-                err_message = ("Die Seitenzahl \"{}\" wird nicht erkannt, wahrscheinlich handelt es sich um einen Tippfehler. Die "
+                err_message = _("Die Seitenzahl \"{}\" wird nicht erkannt, wahrscheinlich handelt es sich um einen Tippfehler. Die "
                     "Seitenzahl wird ignoriert.").format(pnum.identifier)
                 return self.error(err_message, pnum.line_no)
 
@@ -121,11 +121,11 @@ class UniformPagestrings(Mistake):
         second_piece = ''
         # add glue to make messages more readable
         if first_fn == later_fn:
-            second_piece = "später dann aber \"{}\"".format(later_pnum.identifier)
+            second_piece = _("später dann aber \"{}\"").format(later_pnum.identifier)
         else:
-            second_piece = "in der Datei \"{}\" dann aber \"{}\"".format(later_fn, later_pnum.identifier)
-        return self.error("In der Datei \"{}\"  wurde zuerst \"{}\" verwendet, {}. "
-            "Dies sollte einheitlich sein.".format(first_fn, first_pnum.identifier, second_piece), later_pnum.line_no)
+            second_piece = _("in der Datei \"{}\" dann aber \"{}\"").format(later_fn, later_pnum.identifier)
+        return self.error(_("In der Datei \"{}\"  wurde zuerst \"{}\" verwendet, {}. "
+            "Dies sollte einheitlich sein.").format(first_fn, first_pnum.identifier, second_piece), later_pnum.line_no)
 
     def worker(self, *args):
         first = () # (fn, first page number)
@@ -168,10 +168,10 @@ self.threshold."""
                     return self.__error(heading.get_level())
 
     def __error(self, heading_level):
-        return super().error("Es existieren mehr als {} Überschriften der Ebene {}. Das macht das Inhaltsverzeichnis sehr "
+        return super().error(_("Es existieren mehr als {} Überschriften der Ebene {}. Das macht das Inhaltsverzeichnis sehr "
             "unübersichtlich. Man kann entweder in der Konfiguration tocDepth kleiner setzen, um Überschriften "
             "dieser Ebene nicht ins Inhaltsverzeichnis aufzunehmen (für Foliensätze z.B. tocDepth 1) oder die "
-            "Anzahl an Überschriften minimieren, sofern möglich.".format(self.threshold, heading_level), lnum=None)
+            "Anzahl an Überschriften minimieren, sofern möglich.").format(self.threshold, heading_level), lnum=None)
 
 
 class ForgottenNumberInPageNumber(Mistake):
@@ -202,15 +202,15 @@ class ForgottenNumberInPageNumber(Mistake):
             match = ForgottenNumberInPageNumber.HAS_ARABIC_OR_ROMAN.search(line)
             # no match or not one of the groups contains something, it's broken
             if match and not any(match.groups()):
-                return self.error("Wahrscheinlich wurde an dieser Stelle eine Seitenzahl notiert, bei der nach "
-                    "dem Wort die anschließende Nummer vergessen wurde.", start)
+                return self.error(_("Wahrscheinlich wurde an dieser Stelle eine Seitenzahl notiert, bei der nach "
+                    "dem Wort die anschließende Nummer vergessen wurde."), start)
 
 class HeadingOccursMultipleTimes(Mistake):
     """Parse headings; report doubled headings; ignore headings below
 tocDepth."""
     mistake_type = MistakeType.headings
     def worker(self, *args):
-        error_message = ("Überschriften gleichen Namens machen Inhaltsverzeichnisse schwer lesbar und erschweren "
+        error_message = _("Überschriften gleichen Namens machen Inhaltsverzeichnisse schwer lesbar und erschweren "
             "die Navigation. Häufig kommt dies bei Foliensätzen vor. Am Besten man setzt das TocDepth so, "
             "dass nur die Überschrift des Foliensatzes (oft Ebene 1) aufgenommen wird und alle Überschriften, "
             "mitsamt der Überschriften die doppelt sind, gar nicht erst im Inhaltsverzeichnis erscheinen.")
@@ -240,8 +240,8 @@ class PageNumbersWithoutDashes(Mistake):
                 first_ln = first_ln[2:].lstrip()
                 # if all spaces and |'s are stripped, last character and first char must be dashes
                 if not first_ln.startswith('-') or not first_ln.endswith('-'):
-                    return self.error("Es fehlt ein \"-\" in der Seitenzahl. Vorgabe: "
-                                      "\"|| - Seite xyz -\"", num)
+                    return self.error(_("Es fehlt ein \"-\" in der Seitenzahl. Vorgabe: "
+                "\"|| - Seite xyz -\""), num)
 
 class DoNotEmbedHtml(OnelinerMistake):
     """Do not use HTML. Especially, don't use <br/>."""
@@ -255,13 +255,13 @@ class DoNotEmbedHtml(OnelinerMistake):
         if tag and tag not in ['div', 'span']:
             pos_on_line = match.span()[1]
             if tag.lower() == 'br':
-                return self.error("Es sollte kein Umbruch mittels HTML-Tags "
+                return self.error(_("Es sollte kein Umbruch mittels HTML-Tags "
                     "erzeugt werden. Platziert man einen \\ als einziges Zeichen "
                     "auf eine Zeile und lässt davor und danach eine Zeile frei, "
-                    "hat dies denselben Effekt.", lnum=num, pos=pos_on_line)
+                    "hat dies denselben Effekt."), lnum=num, pos=pos_on_line)
             else:
-                return self.error("Es dürfen, bis auf div und span keine HTML-"
-                    "tags in das Markdown-Dokument eingebettet werden.",
+                return self.error(_("Es dürfen, bis auf div und span keine HTML-"
+                    "tags in das Markdown-Dokument eingebettet werden."),
                     lnum=num, pos=pos_on_line)
 
 class EmbeddedHTMLComperators(OnelinerMistake):
@@ -273,8 +273,8 @@ class EmbeddedHTMLComperators(OnelinerMistake):
     def check(self, num, line):
         matched = self.pattern.search(line.lower())
         if matched:
-            return self.error("Relationsoperatoren sollten möglichst nicht mittels HTML, "
-                "sondern besser mittels \\< und \\> erzeugt werden.",
+            return self.error(_("Relationsoperatoren sollten möglichst nicht mittels HTML, "
+                "sondern besser mittels \\< und \\> erzeugt werden."),
                 lnum=num, pos=matched.span()[1])
 
 class HeadingsUseEitherUnderliningOrHashes(Mistake):
@@ -282,8 +282,8 @@ class HeadingsUseEitherUnderliningOrHashes(Mistake):
     def worker(self, *args):
         for heading in args[0]:
             if heading.get_text().startswith('#'):
-                return self.error("Die Überschrift wurde unterstrichen und gleichzeitig mit gekennzeichnet. "
-                    "Am Besten ist es, die da sie sonst als Text angezeigt werden.",
+                return self.error(_("Die Überschrift wurde unterstrichen und gleichzeitig mit gekennzeichnet. "
+                    "Am Besten ist es, die da sie sonst als Text angezeigt werden."),
                     lnum=heading.get_line_number())
 
 class ParagraphMayNotEndOnBackslash(Mistake):
@@ -301,10 +301,10 @@ class ParagraphMayNotEndOnBackslash(Mistake):
     def worker(self, *args):
         for start_line, paragraph in args[0].items():
             if paragraph and paragraph[-1].endswith('\\'):
-                return self.error("Wenn ein Absatz mit einem \\ umgebrochen "
+                return self.error(_("Wenn ein Absatz mit einem \\ umgebrochen "
                     "wird, so wird die nächste (leere) Zeile dem vorigen "
                     "Absatz zugeordnet. Der Absatz geht verloren und in der "
-                    "Folge wird das folgende Element falsch formatiert.",
+                    "Folge wird das folgende Element falsch formatiert."),
                     lnum=start_line + len(paragraph))
 
 class DetectStrayingDollars(OnelinerMistake):
@@ -322,11 +322,11 @@ class DetectStrayingDollars(OnelinerMistake):
                 return
 
         if numDollars % 2: # odd number of dollars
-            return self.error("Eine ungerade Anzahl von Dollar-Zeichen wurde auf der Zeile "
+            return self.error(_("Eine ungerade Anzahl von Dollar-Zeichen wurde auf der Zeile "
                 "entdeckt. Entweder eine Formel wurde nicht geschlossen, oder es wurde "
                 "versucht, eine eingebettete Formel über mehrere Zeilen zu strecken. "
                 "Im ersteren Fall muss ein weiteres Dollar eingefügt werden, im zweiten "
-                "Fall sollte die Formel mit doppelten Dollarzeichen umrahmt werden.", lnum)
+                "Fall sollte die Formel mit doppelten Dollarzeichen umrahmt werden."), lnum)
 
 
 class TextInItemizeShouldntStartWithItemizeCharacter(Mistake):
@@ -365,9 +365,9 @@ This will lead to Pandoc identifying these as sublists.
                         if enumeration_signs >= 2: # it's a proper enumeration
                             break # an error case was encountered
             if errorneous_line:
-                return self.error("In Aufzählungen und Nummerierungen darf "
+                return self.error(_("In Aufzählungen und Nummerierungen darf "
                     "direkt nach dem Aufzählungszeichen nicht ein weiteres Aufzählungszeichen oder eine weitere Nummerierung folgen, "
-                    "da dies sonst als Unterliste erkannt wird. Ein \\ vor dem Zeichen, bzw. bei  Zahlen ein \\ vor dem Punkt verhindert dies.",
+                    "da dies sonst als Unterliste erkannt wird. Ein \\ vor dem Zeichen, bzw. bei  Zahlen ein \\ vor dem Punkt verhindert dies."),
                     lnum=errorneous_line-1)
 
 
@@ -384,8 +384,8 @@ class ToDosInImageDescriptionsAreBad(OnelinerMistake):
 
     def check(self, lnum, line):
         if self._todo_pattern.search(line):
-            return self.error("Die Bildbeschreibung ist wahrscheinlich nicht vollständig, "
-                    "da ein Marker wie \"to do\" gefunden wurde.", lnum=lnum)
+            return self.error(_("Die Bildbeschreibung ist wahrscheinlich nicht vollständig, "
+                    "da ein Marker wie \"to do\" gefunden wurde."), lnum=lnum)
 
 
 class BrokenImageLinksAreDetected(OnelinerMistake):
@@ -404,9 +404,9 @@ class BrokenImageLinksAreDetected(OnelinerMistake):
             # check whether ! [ ] ( ) are all in the line, if so, it's a false positive
             for punct in ['(', ')', '[', ']', '!']:
                 if not punct in line:
-                    return self.error("Ein Bild wurde mit fehlerhafter Syntax "
+                    return self.error(_("Ein Bild wurde mit fehlerhafter Syntax "
                         "eingebunden, wodurch das Bild vom Konverter ignoriert "
-                        "wird.", num)
+                        "wird."), num)
 
 class HyphensFromJustifiedTextWereRemoved(Mistake):
     """When copy-pasting text from i.e. PDFs, it is easy to forget to remove
@@ -434,10 +434,10 @@ class HyphensFromJustifiedTextWereRemoved(Mistake):
                     # it was justified text, if next line starts with a word
                     if next_line and next_line[0].isalpha() and not \
                             (next_line.startswith('und') or next_line.startswith('and')):
-                        return self.error("Es wurde ein Trennstrich gefunden, "
+                        return self.error(_("Es wurde ein Trennstrich gefunden, "
                             "der wahrscheinlich aus einem Text mit "
                             "Blocksatz kopiert wurde. Dies wird in der "
-                            "Ausgabe falsch formatiert werden.", start_line + lnum)
+                            "Ausgabe falsch formatiert werden."), start_line + lnum)
 
 
 class DetectEmptyImageDescriptions(Mistake):
@@ -476,5 +476,5 @@ class DetectEmptyImageDescriptions(Mistake):
                     image_description_found = True
                     break
             if not image_description_found:
-                return self.error("Es wurde keine Bildbeschreibung eingefügt.",
+                return self.error(_("Es wurde keine Bildbeschreibung eingefügt."),
                     lnum=start_line, path=path)

--- a/MAGSBS/quality_assurance/meta.py
+++ b/MAGSBS/quality_assurance/meta.py
@@ -10,6 +10,7 @@ mistake."""
 
 from abc import ABCMeta, abstractmethod
 import enum
+from ..config import _
 
 class MistakeType(enum.Enum):
     """The mistake type determines the arguments and the environment in which to
@@ -57,7 +58,7 @@ should set the relevant properties in the constructor."""
     def set_file_types(self, types):
         # is it list-alike
         if not (hasattr(types, '__iter__') or hasattr(types, '__getitem__')):
-            raise TypeError("List or tuple expected.")
+            raise TypeError(_("List or tuple expected."))
         self.__file_types = types
 
     def get_file_types(self):
@@ -108,7 +109,7 @@ It'll save typing."""
 
     def worker(self, *args):
         if len(args) != 2:
-            raise ValueError("For a mistake checker of type oneliner, exactly two arguments are required.")
+            raise ValueError(_("For a mistake checker of type oneliner, exactly two arguments are required."))
         return self.check(args[0], args[1])
 
 

--- a/MAGSBS/quality_assurance/mistkerl.py
+++ b/MAGSBS/quality_assurance/mistkerl.py
@@ -32,6 +32,7 @@ from .. import errors
 from .. import filesystem as filesystem
 from .. import mparser
 from .. import roman
+from ..config import _
 
 from .all_formats import *
 from .latex import *
@@ -112,7 +113,7 @@ recursively."""
                         paragraphs = mparser.rm_codeblocks(
                                 mparser.file2paragraphs(f.read(), join_lines=True))
                 except UnicodeDecodeError:
-                    msg = "Datei ist nicht in UTF-8 kodiert, bitte waehle \"UTF-8\" als Zeichensatz im Editor."
+                    msg = _("Datei ist nicht in UTF-8 kodiert, bitte waehle \"UTF-8\" als Zeichensatz im Editor.")
                     e = ErrorMessage(msg, 1, file_path)
                     self.__append_error(path, e)
                     continue
@@ -127,7 +128,7 @@ recursively."""
         """Add an error to the internal output dict."""
         if not err: return
         if not isinstance(err, ErrorMessage):
-            raise TypeError("Errors may only be of type ErrorMessage, got '{}'".format(str(err)))
+            raise TypeError(_("Errors may only be of type ErrorMessage, got '{}'").format(str(err)))
         if not err.path:
             err.path = path
         if os.path.dirname(err.path) == '.':
@@ -200,8 +201,8 @@ recursively."""
                 self.__append_error(path, issue.run(path))
             except ET.ParseError as e:
                 pos = e.position
-                mistake = ErrorMessage("Die Konfiguration konnte nicht gelesen"
-                    " werden: {}".format(e.args[0]), pos[0], path)
+                mistake = ErrorMessage(_("Die Konfiguration konnte nicht gelesen"
+                    " werden: {}").format(e.args[0]), pos[0], path)
                 mistake.pos_on_line = pos[1]
                 self.__append_error(path, mistake)
 
@@ -210,7 +211,7 @@ recursively."""
             return # ignore empty files
         last_par = next(reversed(paragraphs))
         if last_par > 2500:
-            msg = ("Die Datei ist zu lang. Um die Navigation zu erleichtern und "
+            msg = _("Die Datei ist zu lang. Um die Navigation zu erleichtern und "
                 "die einfache Lesbarkeit zu gewährleisten sollten lange Kapitel"
                 " mit mehr als 2500 Zeilen in mehrere Unterdateien nach dem "
                 "Schema kxxyy.md oder kleiner aufgeteilt werden.")

--- a/README.md
+++ b/README.md
@@ -78,3 +78,15 @@ this:
     python setup.py install
 
 You can run `matuc` straight away.
+
+Localization
+------------
+
+For correct running of different language versions, it is now necessary to
+manually generate .mo files and create appropriate structure given by
+[gettext](https://docs.python.org/3/library/gettext.html), i.e.
+localedir/language/LC_MESSAGES/domain.mo for each language (encoded using
+two-letter codes given by [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes)).
+
+For generation, you can use the e.g. the [msgfmt script]
+(http://refspecs.linuxbase.org/LSB_3.0.0/LSB-PDA/LSB-PDA/msgfmt.html)

--- a/locale/cs/LC_MESSAGES/messages.po
+++ b/locale/cs/LC_MESSAGES/messages.po
@@ -1,0 +1,173 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR ORGANIZATION
+# xplhak <xplhak@fi.muni.cz>, 2018.
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"POT-Creation-Date: 2018-02-09 14:02+0100\n"
+"PO-Revision-Date: 2018-02-15 16:57+0100\n"
+"Last-Translator: xplhak <xplhak@fi.muni.cz>\n"
+"Language-Team: TUD\n"
+"Language: cs\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
+"X-Generator: Poedit 2.0.6\n"
+"Generated-By: pygettext.py 1.5\n"
+
+#: all_formats.py:31
+msgid "Fehler in der Konfiguration: Der Wert {} ist nicht gesetzt, wodurch die Kopfdaten in den HTML-Dateien nicht erzeugt werden können."
+msgstr "Chyba konfigurace: Hodnota {} není nastavena, což znamená, že záhlaví v HTML souborech nelze generovat."
+
+#: all_formats.py:54
+msgid "Es wurden inkorrekt dargestellte Umlaute gefunden. Dies geschieht oft, wenn Text aus PDF-Dateien kopiert wird. Das macht den Text allerdings schwer leserlich."
+msgstr "Byly nalezeny nesprávně zobrazené nápisy. To se často stává, když je text zkopírován ze souborů PDF. To ztěžuje čtení textu."
+
+#: all_formats.py:69
+msgid "Die Datei \"{}\" ist falsch benannt und folgt nicht den Namenskonventionen. Dies führt zu einer falschen Verwendung der Datei."
+msgstr "Soubor (adresář) \"{}\" je pojmenován nesprávně a nedodržuje konvence pojmenování. To může vést k nesprávnému použití souboru."
+
+#: latex.py:31
+msgid "Die LaTeX-Umgebung zur Fallunterscheidung (cases) sollte Zeilenumbrüche an den passenden Stellen enthalten, um die Lesbarkeit zu gewährleisten."
+msgstr "Pro lepší čitelnost textu sázeného pomocí LaTeXu prosím použijte zalamování řádků (na vhodných místech)."
+
+#: latex.py:49
+msgid "Matrizen sollten, damit sie einfach lesbar sind, nicht mit \\left\\(..., sondern einfach mit \\begin{pmatrix}...  erzeugt werden. Dabei werden auch Klammern automatisch gesetzt und es ist kürzer."
+msgstr "Pro lepší čitelnost nevytvářejte matice pomocí \\left\\(...), ale jednoduše pomocí \\begin{pmatrix}... Závorky se poté nastavují automaticky a jsou kratší."
+
+#: latex.py:64
+msgid "Jede Zeile einer Matrix oder Tabelle sollte zur besseren Lesbarkeit auf eine eigene Zeile gesetzt werden."
+msgstr "Každý řádek matice nebo tabulky by měl být umístěn na samostatném řádku pro čitelnost."
+
+#: latex.py:82
+msgid "Anstatt einen Umlaut zu schreiben, wurde eine LaTeX-Kontrollsequenz verwendet. Das ist schwer leserlich und kann außerdem einfach durch setzen des Zeichensatzes umgangen werden."
+msgstr "Namísto zápisu písmene s přehláskou byla použita kontrolní sekvence LaTeXu. Tuto formu zápisu písmen s přehláskou je obtížné číst a lze ji snadno nahradit využitím vhodné znakové sady."
+
+#: latex.py:100
+msgid "Formeln in einem Absatz (umgeben von Text), müssen mit einfachen $-Zeichen gesetzt werden, da sich die Formeln sonst in der Ausgabe nicht in den Text integrieren. $$ (display math) sollte für einzeln stehende Formeln verwendet werden."
+msgstr "Vzorce uvedené přímo v odstavci (obklopené textem) musí být vloženy pomocí jednoduchých znaků $, jinak se vzorce nevloží do výstupního textu. $$ (matematické zobrazení) by mělo být použito pro samostatné vzorce."
+
+#: latex.py:112
+msgid "Leerräume in Formeln sollten mit \\quad oder \\qquad gekennzeichnet werden, da sie sonst mit Sprachausgabe schwer lesbar sind."
+msgstr "Mezery ve vzorcích by měly být vysázeny pomocí \\quad či \\qquad, jiná sazba způsobuje problémy při čtení odčítačem obrazovky."
+
+#: latex.py:134
+msgid "{0} sollte in LaTeX-Formeln grundsätzlich als Befehl gesetzt werden, d.h. mittels \\{0}. Nur so wird es in der Ausgabe korrekt formatiert und ist gleichzeitig gut lesbar."
+msgstr "Funkce {0} by měla být vždy nastavena jako příkaz ve vzorcích v LaTeXu, tj. pomocí \\{0}. V opačném případě nebude na výstupu správně naformátován a tedy ani čitelný."
+
+#: latex.py:155
+msgid "Eine Formel, die einzeln in einem Absatz steht, wurde als eingebettete Formel mit einfachen $ gesetzt. Stattdessen sollten doppelte Dollarzeichen verwendet werden, da dies verhindert, dass LaTeX die Formel auf Zeilenhöhe staucht."
+msgstr "Pro vzorec, který je vložen jako samostatný odstavec, by neměla být použita syntaxe s jednoduchým znakem $. Namísto toho by měly být použity dva dolarové znaky, což zabrání LaTeXu, aby přerušil vzorec ve výšce řádku."
+
+#: markdown.py:19
+msgid "Jede Seitenzahl muss in der Zeile darueber oder darunter eine Leerzeile haben, das heißt sie muss in einem eigenen Absatz stehen."
+msgstr "Nad (či pod) číslem každé stránky musí být prázdný řádek, tj. musí být v samostatném odstavci."
+
+#: markdown.py:48
+msgid "In diesem Verzeichnis gibt es mehr als eine Überschrift der Ebene 1. Dies ist nicht erlaubt. Beispielsweise hat jeder Foliensatz nur eine Hauptüberschrift und auch ein Kapitel wird nur mit einer Überschrift bezeichnet."
+msgstr "V tomto adresáři je více než jeden nadpis úrovně 1, což není povoleno. Například každá sada slajdů může mít pouze jeden hlavní nadpis úrovně 1 a slajd je označena pouze nadpisem úrovně 2."
+
+#: markdown.py:88
+msgid "Eine Aufzählung muss in einem eigenen Absatz stehen, d. h. es muss davor und danach eine Leerzeile sein."
+msgstr "Výčet musí být uveden v samostatném odstavci, tj. prázdný řádek musí být před i za výčtem."
+
+#: markdown.py:107
+msgid "Die Seitenzahl \"{}\" wird nicht erkannt, wahrscheinlich handelt es sich um einen Tippfehler. Die Seitenzahl wird ignoriert."
+msgstr "Číslo stránky \"{}\" není rozpoznáno a je ignorováno. Jedná se pravděpodobně o překlep."
+
+#: markdown.py:124
+msgid "später dann aber \"{}\""
+msgstr "následně ale \"{}\""
+
+#: markdown.py:126
+msgid "in der Datei \"{}\" dann aber \"{}\""
+msgstr "v souboru \"{}\", ale následně \"{}\""
+
+#: markdown.py:127
+msgid "In der Datei \"{}\"  wurde zuerst \"{}\" verwendet, {}. Dies sollte einheitlich sein."
+msgstr "V souboru \"{}\" byl používán nejprve \"{}\", {}. To by ale mělo být konzistentní."
+
+#: markdown.py:171
+msgid "Es existieren mehr als {} Überschriften der Ebene {}. Das macht das Inhaltsverzeichnis sehr unübersichtlich. Man kann entweder in der Konfiguration tocDepth kleiner setzen, um Überschriften dieser Ebene nicht ins Inhaltsverzeichnis aufzunehmen (für Foliensätze z.B. tocDepth 1) oder die Anzahl an Überschriften minimieren, sofern möglich."
+msgstr "Existuje více než {} záhlaví úrovně {}. Obsah je proto velmi matoucí. Můžete buď zmenšit tocDepth v konfiguraci tak, aby nadpisy této úrovně nebyly do obsahu zahrnuty (například pro slajdy nastavit tocDepth 1), nebo, pokud je to možné, snižte počet nadpisů této úrovně."
+
+#: markdown.py:205
+msgid "Wahrscheinlich wurde an dieser Stelle eine Seitenzahl notiert, bei der nach dem Wort die anschließende Nummer vergessen wurde."
+msgstr "Pravděpodobně bylo uvedeno označení stránky, ve kterém nebylo uvedeno číslo."
+
+#: markdown.py:213
+msgid "Überschriften gleichen Namens machen Inhaltsverzeichnisse schwer lesbar und erschweren die Navigation. Häufig kommt dies bei Foliensätzen vor. Am Besten man setzt das TocDepth so, dass nur die Überschrift des Foliensatzes (oft Ebene 1) aufgenommen wird und alle Überschriften, mitsamt der Überschriften die doppelt sind, gar nicht erst im Inhaltsverzeichnis erscheinen."
+msgstr "Stejné nadpisy způsobují, že obsah je obtížné číst, což ztěžuje to i navigaci. Toto se často stává u slajdů. Nejlepším způsobem, je nastavit TocDepth tak, aby byl použit pouze nadpis sady snímků (často úroveň 1) a v obsahu se neobleví opakující se nadpisy."
+
+#: markdown.py:243
+msgid "Es fehlt ein \"-\" in der Seitenzahl. Vorgabe: \"|| - Seite xyz -\""
+msgstr "V označení stránky chybí \"-\". Výchozí hodnota: \"|| - stránka xyz -\""
+
+#: markdown.py:258
+msgid "Es sollte kein Umbruch mittels HTML-Tags erzeugt werden. Platziert man einen \\ als einziges Zeichen auf eine Zeile und lässt davor und danach eine Zeile frei, hat dies denselben Effekt."
+msgstr "Pro zalamování by nemělo být použito značek HTML. Stejného efektu docílíte, pokud umístíte na řádek jako jediný znak \\ (a zároveň ponecháte řádky před a po prázdné)."
+
+#: markdown.py:263
+msgid "Es dürfen, bis auf div und span keine HTML-tags in das Markdown-Dokument eingebettet werden."
+msgstr "Není povoleno vkládat HTML tagy do Markdown dokumentu (s výjimkou div a span)."
+
+#: markdown.py:276
+msgid "Relationsoperatoren sollten möglichst nicht mittels HTML, sondern besser mittels \\< und \\> erzeugt werden."
+msgstr "Relační operátoři by s výhodou neměli být generováni pomocí HTML, ale lépe pomocí \\< a \\>."
+
+#: markdown.py:285
+msgid "Die Überschrift wurde unterstrichen und gleichzeitig mit gekennzeichnet. Am Besten ist es, die da sie sonst als Text angezeigt werden."
+msgstr "Nadpis byl současně podtržen i označen. Nejlepší je, aby se zobrazoval jako text."
+
+#: markdown.py:304
+msgid "Wenn ein Absatz mit einem \\ umgebrochen wird, so wird die nächste (leere) Zeile dem vorigen Absatz zugeordnet. Der Absatz geht verloren und in der Folge wird das folgende Element falsch formatiert."
+msgstr "Pokud je odstavec zabalen s \\, další (prázdný) řádek je přiřazen předchozímu odstavci. Tento odstavec je ztracen a následně je nesprávně formátován následující prvek."
+
+#: markdown.py:325
+msgid "Eine ungerade Anzahl von Dollar-Zeichen wurde auf der Zeile entdeckt. Entweder eine Formel wurde nicht geschlossen, oder es wurde versucht, eine eingebettete Formel über mehrere Zeilen zu strecken. Im ersteren Fall muss ein weiteres Dollar eingefügt werden, im zweiten Fall sollte die Formel mit doppelten Dollarzeichen umrahmt werden."
+msgstr "Na řádku byl zjištěn lichý počet znaků dolar. Nebyl buď uzavřen vzorec nebo došlo k pokusu o rozdělení vloženého vzorce na několik řádků. V prvním případě musí být do vzorce vložen další znak dolar, ve druhém případě by měly být pro vzorec použity dva dolarové znaky za sebou."
+
+#: markdown.py:368
+msgid "In Aufzählungen und Nummerierungen darf direkt nach dem Aufzählungszeichen nicht ein weiteres Aufzählungszeichen oder eine weitere Nummerierung folgen, da dies sonst als Unterliste erkannt wird. Ein \\ vor dem Zeichen, bzw. bei  Zahlen ein \\ vor dem Punkt verhindert dies."
+msgstr "Při označení vyčtu a číslování by neměla být pomlčka následována další pomlčkou nebo číslováním, jinak bude rozpoznáno jako dílčí seznam. Znak \\ před pomlčkou (nebo před tečkou u číslování) tomuto zabrání."
+
+#: markdown.py:387
+msgid "Die Bildbeschreibung ist wahrscheinlich nicht vollständig, da ein Marker wie \"to do\" gefunden wurde."
+msgstr "Popis obrázku pravděpodobně není úplný, protože byla nalezena značka \"to do\"."
+
+#: markdown.py:407
+msgid "Ein Bild wurde mit fehlerhafter Syntax eingebunden, wodurch das Bild vom Konverter ignoriert wird."
+msgstr "Obrázek nebyl vložen pomocí správné syntaxe a ignoroval svůj obraz."
+
+#: markdown.py:437
+msgid "Es wurde ein Trennstrich gefunden, der wahrscheinlich aus einem Text mit Blocksatz kopiert wurde. Dies wird in der Ausgabe falsch formatiert werden."
+msgstr "Byla nalezena pomlčka, která byla pravděpodobně zkopírována z textu s odůvodněním. To bude nesprávně formátováno na výstupu."
+
+#: markdown.py:479
+msgid "Es wurde keine Bildbeschreibung eingefügt."
+msgstr "Nebyl vložen popis obrázku."
+
+#: meta.py:60
+msgid "List or tuple expected."
+msgstr "Byl očekáván seznam nebo n-tice."
+
+#: meta.py:111
+msgid "For a mistake checker of type oneliner, exactly two arguments are required."
+msgstr "Modul kontrolující chyby typu oneliner vyžaduje přesně dva argumenty."
+
+#: mistkerl.py:125
+msgid "Datei ist nicht in UTF-8 kodiert, bitte waehle \"UTF-8\" als Zeichensatz im Editor."
+msgstr "Soubor není zakódován pomocí UTF-8. Prosím zvolte v editoru kódování znaků \"UTF-8\"."
+
+#: mistkerl.py:140
+msgid "Errors may only be of type ErrorMessage, got '{}'"
+msgstr "Chyby mohou být pouze typu ErrorMessage, byl vrácen typ '{}'"
+
+#: mistkerl.py:213
+msgid "Die Konfiguration konnte nicht gelesen werden: {}"
+msgstr "Nebylo možné načíst soubor s konfigurací: {}"
+
+#: mistkerl.py:223
+msgid "Die Datei ist zu lang. Um die Navigation zu erleichtern und die einfache Lesbarkeit zu gewährleisten sollten lange Kapitel mit mehr als 2500 Zeilen in mehrere Unterdateien nach dem Schema kxxyy.md oder kleiner aufgeteilt werden."
+msgstr "Soubor je příliš dlouhý. Pro usnadnění navigace a zajištění snadné čitelnosti by měly být dlouhé kapitoly (s více než 2500 řádky)rozděleny do několika dílčích souborů podle schématu kxxyy.md."

--- a/locale/cs/LC_MESSAGES/messages.po
+++ b/locale/cs/LC_MESSAGES/messages.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "POT-Creation-Date: 2018-02-09 14:02+0100\n"
-"PO-Revision-Date: 2018-02-15 16:57+0100\n"
+"PO-Revision-Date: 2018-02-19 09:19+0100\n"
 "Last-Translator: xplhak <xplhak@fi.muni.cz>\n"
 "Language-Team: TUD\n"
 "Language: cs\n"
@@ -69,8 +69,8 @@ msgid "In diesem Verzeichnis gibt es mehr als eine Überschrift der Ebene 1. Die
 msgstr "V tomto adresáři je více než jeden nadpis úrovně 1, což není povoleno. Například každá sada slajdů může mít pouze jeden hlavní nadpis úrovně 1 a slajd je označena pouze nadpisem úrovně 2."
 
 #: markdown.py:88
-msgid "Eine Aufzählung muss in einem eigenen Absatz stehen, d. h. es muss davor und danach eine Leerzeile sein."
-msgstr "Výčet musí být uveden v samostatném odstavci, tj. prázdný řádek musí být před i za výčtem."
+msgid "Eine Aufzählung muss in einem eigenen Absatz stehen, d. h. es muss zumindest davor eine Leerzeile existieren."
+msgstr "Výčet musí být uveden v samostatném odstavci, tj. před výčtem musí být alespoň jeden prázdný řádek."
 
 #: markdown.py:107
 msgid "Die Seitenzahl \"{}\" wird nicht erkannt, wahrscheinlich handelt es sich um einen Tippfehler. Die Seitenzahl wird ignoriert."

--- a/locale/de/LC_MESSAGES/messages.po
+++ b/locale/de/LC_MESSAGES/messages.po
@@ -1,0 +1,25 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR ORGANIZATION
+# xplhak <xplhak@fi.muni.cz>, 2018.
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"POT-Creation-Date: 2018-02-09 15:15+0100\n"
+"PO-Revision-Date: 2018-02-15 17:33+0100\n"
+"Last-Translator: xplhak <xplhak@fi.muni.cz>\n"
+"Language-Team: TUD\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 2.0.6\n"
+"Generated-By: pygettext.py 1.5\n"
+
+#: meta.py:60
+msgid "List or tuple expected."
+msgstr "Liste oder Tupel erwartet."
+
+#: meta.py:111
+msgid "For a mistake checker of type oneliner, exactly two arguments are required."
+msgstr "Für eine Fehlerüberprüfung vom Typ oneliner sind genau zwei Argumente erforderlich."

--- a/locale/en/LC_MESSAGES/messages.po
+++ b/locale/en/LC_MESSAGES/messages.po
@@ -37,8 +37,8 @@ msgid "In diesem Verzeichnis gibt es mehr als eine Überschrift der Ebene 1. Die
 msgstr "There is more than one Level 1 heading in this directory. This is not allowed. For example, each set of slides has only one main heading and also a chapter is labeled with a headline only."
 
 #: markdown.py:88
-msgid "Eine Aufzählung muss in einem eigenen Absatz stehen, d. h. es muss davor und danach eine Leerzeile sein."
-msgstr "An enumeration must be in a separate paragraph, d. H. it must be before and after a blank line."
+msgid "Eine Aufzählung muss in einem eigenen Absatz stehen, d. h. es muss zumindest davor eine Leerzeile existieren."
+msgstr "An enumeration must be in a separate paragraph, d. H. it must be before a blank line."
 
 #: markdown.py:107
 msgid "Die Seitenzahl \"{}\" wird nicht erkannt, wahrscheinlich handelt es sich um einen Tippfehler. Die Seitenzahl wird ignoriert."

--- a/locale/en/LC_MESSAGES/messages.po
+++ b/locale/en/LC_MESSAGES/messages.po
@@ -1,0 +1,165 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR ORGANIZATION
+# xplhak <xplhak@fi.muni.cz>, 2018.
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"POT-Creation-Date: 2018-02-09 14:02+0100\n"
+"PO-Revision-Date: 2018-02-15 17:40+0100\n"
+"Last-Translator: xplhak <xplhak@fi.muni.cz>\n"
+"Language-Team: TUD\n"
+"Language: en\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 2.0.6\n"
+"Generated-By: pygettext.py 1.5\n"
+
+#: all_formats.py:31
+msgid "Fehler in der Konfiguration: Der Wert {} ist nicht gesetzt, wodurch die Kopfdaten in den HTML-Dateien nicht erzeugt werden können."
+msgstr "Error in configuration: The value {} is not set, which means that the header data in the HTML files can not be generated."
+
+#: all_formats.py:54
+msgid "Es wurden inkorrekt dargestellte Umlaute gefunden. Dies geschieht oft, wenn Text aus PDF-Dateien kopiert wird. Das macht den Text allerdings schwer leserlich."
+msgstr "Incorrectly displayed umlauts were found. This often happens when text is copied from PDF files. That makes the text, however, difficult to read."
+
+#: all_formats.py:69
+msgid "Die Datei \"{}\" ist falsch benannt und folgt nicht den Namenskonventionen. Dies führt zu einer falschen Verwendung der Datei."
+msgstr "The file \"{}\" is named incorrectly and does not follow the naming conventions. This leads to a wrong use of the file."
+
+#: markdown.py:19
+msgid "Jede Seitenzahl muss in der Zeile darueber oder darunter eine Leerzeile haben, das heißt sie muss in einem eigenen Absatz stehen."
+msgstr "Each page number must have an empty line in the line above or below, i.e. it must be in a separate paragraph."
+
+#: markdown.py:48
+msgid "In diesem Verzeichnis gibt es mehr als eine Überschrift der Ebene 1. Dies ist nicht erlaubt. Beispielsweise hat jeder Foliensatz nur eine Hauptüberschrift und auch ein Kapitel wird nur mit einer Überschrift bezeichnet."
+msgstr "There is more than one Level 1 heading in this directory. This is not allowed. For example, each set of slides has only one main heading and also a chapter is labeled with a headline only."
+
+#: markdown.py:88
+msgid "Eine Aufzählung muss in einem eigenen Absatz stehen, d. h. es muss davor und danach eine Leerzeile sein."
+msgstr "An enumeration must be in a separate paragraph, d. H. it must be before and after a blank line."
+
+#: markdown.py:107
+msgid "Die Seitenzahl \"{}\" wird nicht erkannt, wahrscheinlich handelt es sich um einen Tippfehler. Die Seitenzahl wird ignoriert."
+msgstr "The page number \"{}\" is not recognized, it is probably a typo. The page number is ignored."
+
+#: markdown.py:124
+msgid "später dann aber \"{}\""
+msgstr "later but then \"{}\""
+
+#: markdown.py:126
+msgid "in der Datei \"{}\" dann aber \"{}\""
+msgstr "in the file \"{}\" but then \"{}\""
+
+#: markdown.py:127
+msgid "In der Datei \"{}\"  wurde zuerst \"{}\" verwendet, {}. Dies sollte einheitlich sein."
+msgstr "In the file \"{}\" \"{}\" was used first, {}. This should be consistent."
+
+#: markdown.py:171
+msgid "Es existieren mehr als {} Überschriften der Ebene {}. Das macht das Inhaltsverzeichnis sehr unübersichtlich. Man kann entweder in der Konfiguration tocDepth kleiner setzen, um Überschriften dieser Ebene nicht ins Inhaltsverzeichnis aufzunehmen (für Foliensätze z.B. tocDepth 1) oder die Anzahl an Überschriften minimieren, sofern möglich."
+msgstr "There are more than {} headers {}. This makes the table of contents very confusing. You can either set tocDepth smaller in the configuration so that headings of this level are not included in the table of contents (for example, for slide sets tocDepth 1) or minimize the number of headings, if possible."
+
+#: markdown.py:205
+msgid "Wahrscheinlich wurde an dieser Stelle eine Seitenzahl notiert, bei der nach dem Wort die anschließende Nummer vergessen wurde."
+msgstr "Probably at this point a page number was noted, in which after the word the following number was forgotten."
+
+#: markdown.py:213
+msgid "Überschriften gleichen Namens machen Inhaltsverzeichnisse schwer lesbar und erschweren die Navigation. Häufig kommt dies bei Foliensätzen vor. Am Besten man setzt das TocDepth so, dass nur die Überschrift des Foliensatzes (oft Ebene 1) aufgenommen wird und alle Überschriften, mitsamt der Überschriften die doppelt sind, gar nicht erst im Inhaltsverzeichnis erscheinen."
+msgstr "Headings of the same name make tables of contents difficult to read and make navigation difficult. This often happens with film sets. The best way to set the TocDepth so that only the headline of the slide set (often level 1) is recorded and all headings, together with the headings are twice, not even appear in the table of contents."
+
+#: markdown.py:243
+msgid "Es fehlt ein \"-\" in der Seitenzahl. Vorgabe: \"|| - Seite xyz -\""
+msgstr "There is a missing \"-\" in the page number. Default: \"|| - Page xyz -\""
+
+#: markdown.py:258
+msgid "Es sollte kein Umbruch mittels HTML-Tags erzeugt werden. Platziert man einen \\ als einziges Zeichen auf eine Zeile und lässt davor und danach eine Zeile frei, hat dies denselben Effekt."
+msgstr "It should be generated no break using HTML tags. If you place a \\ as the only character on a line and release a line before and after, this has the same effect."
+
+#: markdown.py:263
+msgid "Es dürfen, bis auf div und span keine HTML-tags in das Markdown-Dokument eingebettet werden."
+msgstr "It is not allowed to embed HTML tags in the Markdown document except for div and span."
+
+#: markdown.py:276
+msgid "Relationsoperatoren sollten möglichst nicht mittels HTML, sondern besser mittels \\< und \\> erzeugt werden."
+msgstr "Relational operators should preferably not be generated by means of HTML, but better by means of \\ <and \\>."
+
+#: markdown.py:285
+msgid "Die Überschrift wurde unterstrichen und gleichzeitig mit gekennzeichnet. Am Besten ist es, die da sie sonst als Text angezeigt werden."
+msgstr "The headline was underlined and marked at the same time. It is best that they are otherwise displayed as text."
+
+#: markdown.py:304
+msgid "Wenn ein Absatz mit einem \\ umgebrochen wird, so wird die nächste (leere) Zeile dem vorigen Absatz zugeordnet. Der Absatz geht verloren und in der Folge wird das folgende Element falsch formatiert."
+msgstr "If a paragraph is wrapped with a \\, the next (empty) line is assigned to the previous paragraph. The paragraph is lost and subsequently the following element is formatted incorrectly."
+
+#: markdown.py:325
+msgid "Eine ungerade Anzahl von Dollar-Zeichen wurde auf der Zeile entdeckt. Entweder eine Formel wurde nicht geschlossen, oder es wurde versucht, eine eingebettete Formel über mehrere Zeilen zu strecken. Im ersteren Fall muss ein weiteres Dollar eingefügt werden, im zweiten Fall sollte die Formel mit doppelten Dollarzeichen umrahmt werden."
+msgstr "An odd number of dollar signs was discovered on the line. Either a formula was not closed or an attempt was made to stretch an embedded formula over several lines. In the former case, another dollar must be inserted, in the second case, the formula should be framed with double dollar signs."
+
+#: markdown.py:368
+msgid "In Aufzählungen und Nummerierungen darf direkt nach dem Aufzählungszeichen nicht ein weiteres Aufzählungszeichen oder eine weitere Nummerierung folgen, da dies sonst als Unterliste erkannt wird. Ein \\ vor dem Zeichen, bzw. bei  Zahlen ein \\ vor dem Punkt verhindert dies."
+msgstr "Enumeration and numbering should not be followed by a bullet or numbering immediately after the bullet point, otherwise this will be recognized as a sublist. A \\ in front of the character, or with numbers a \\ before the dot prevents this."
+
+#: markdown.py:387
+msgid "Die Bildbeschreibung ist wahrscheinlich nicht vollständig, da ein Marker wie \"to do\" gefunden wurde."
+msgstr "The image description is probably not complete because a marker like \"to do\" was found."
+
+#: markdown.py:407
+msgid "Ein Bild wurde mit fehlerhafter Syntax eingebunden, wodurch das Bild vom Konverter ignoriert wird."
+msgstr "An image was included with incorrect syntax, ignoring the image from the converter."
+
+#: markdown.py:437
+msgid "Es wurde ein Trennstrich gefunden, der wahrscheinlich aus einem Text mit Blocksatz kopiert wurde. Dies wird in der Ausgabe falsch formatiert werden."
+msgstr "A hyphen was found that was probably copied from a text with justification. This will be incorrectly formatted in the output."
+
+#: markdown.py:479
+msgid "Es wurde keine Bildbeschreibung eingefügt."
+msgstr "No image description has been inserted."
+
+#: latex.py:31
+msgid "Die LaTeX-Umgebung zur Fallunterscheidung (cases) sollte Zeilenumbrüche an den passenden Stellen enthalten, um die Lesbarkeit zu gewährleisten."
+msgstr "The LaTeX case-to-case environment should include line breaks at the appropriate locations for readability."
+
+#: latex.py:49
+msgid "Matrizen sollten, damit sie einfach lesbar sind, nicht mit \\left\\(..., sondern einfach mit \\begin{pmatrix}...  erzeugt werden. Dabei werden auch Klammern automatisch gesetzt und es ist kürzer."
+msgstr "Matrices should not be created with \\ left \\ (..., but simply with \\ begin {pmatrix} ... so that they are easy to read. Also brackets are set automatically and it is shorter."
+
+#: latex.py:64
+msgid "Jede Zeile einer Matrix oder Tabelle sollte zur besseren Lesbarkeit auf eine eigene Zeile gesetzt werden."
+msgstr "Each row of a matrix or table should be placed on a separate line for readability."
+
+#: latex.py:82
+msgid "Anstatt einen Umlaut zu schreiben, wurde eine LaTeX-Kontrollsequenz verwendet. Das ist schwer leserlich und kann außerdem einfach durch setzen des Zeichensatzes umgangen werden."
+msgstr "Instead of writing an umlaut, a LaTeX control sequence was used. This is difficult to read and can also be easily bypassed by setting the character set."
+
+#: latex.py:100
+msgid "Formeln in einem Absatz (umgeben von Text), müssen mit einfachen $-Zeichen gesetzt werden, da sich die Formeln sonst in der Ausgabe nicht in den Text integrieren. $$ (display math) sollte für einzeln stehende Formeln verwendet werden."
+msgstr "Formulas in a paragraph (surrounded by text) must be set with simple $ characters, otherwise the formulas will not be included in the text in the output. $$ (display math) should be used for standalone formulas."
+
+#: latex.py:112
+msgid "Leerräume in Formeln sollten mit \\quad oder \\qquad gekennzeichnet werden, da sie sonst mit Sprachausgabe schwer lesbar sind."
+msgstr "Spaces in formulas should be labeled \\ quad or \\ qquad, otherwise they are difficult to read with speech."
+
+#: latex.py:134
+msgid "{0} sollte in LaTeX-Formeln grundsätzlich als Befehl gesetzt werden, d.h. mittels \\{0}. Nur so wird es in der Ausgabe korrekt formatiert und ist gleichzeitig gut lesbar."
+msgstr "{0} should always be set as a command in LaTeX formulas, i. by means of \\ {0}. Only then will it be formatted correctly in the output and at the same time readable."
+
+#: latex.py:155
+msgid "Eine Formel, die einzeln in einem Absatz steht, wurde als eingebettete Formel mit einfachen $ gesetzt. Stattdessen sollten doppelte Dollarzeichen verwendet werden, da dies verhindert, dass LaTeX die Formel auf Zeilenhöhe staucht."
+msgstr "A formula that stands alone in a paragraph was set as an embedded formula with a simple $. Instead, double dollar signs should be used as this will prevent LaTeX from upsetting the formula at line height."
+
+#: mistkerl.py:125
+msgid "Datei ist nicht in UTF-8 kodiert, bitte waehle \"UTF-8\" als Zeichensatz im Editor."
+msgstr "File is not encoded in UTF-8, please select \"UTF-8\" as a character set in the editor."
+
+#: mistkerl.py:140
+msgid "Errors may only be of type ErrorMessage, got '{}'"
+msgstr "Errors may be of type ErrorMessage, got '{}'"
+
+#: mistkerl.py:213
+msgid "Die Konfiguration konnte nicht gelesen werden: {}"
+msgstr "The configuration could not be read: {}"
+
+#: mistkerl.py:223
+msgid "Die Datei ist zu lang. Um die Navigation zu erleichtern und die einfache Lesbarkeit zu gewährleisten sollten lange Kapitel mit mehr als 2500 Zeilen in mehrere Unterdateien nach dem Schema kxxyy.md oder kleiner aufgeteilt werden."
+msgstr "The file is too long. To facilitate navigation and to ensure easy readability, long chapters with more than 2500 lines should be split into several subfiles of the schema kxxyy.md or smaller."


### PR DESCRIPTION
This should be the first version. What is still in the development:
- undescore function is called in the config file, but not in the Translation class (and setup_i18n function);
- .mo files should be generated during installation (this topic closely relate to the directory structure, where .po files are stored - current structure makes a testing easier);
- translation should be manually revised;
- translation should be done for rest of the system;
- only english strings should be (probably) in the code (this is also something that could be discussed) 