### PR TITLE
Linkchecker - position on line added for references, mparser update 

### DIFF
--- a/MAGSBS/datastructures.py
+++ b/MAGSBS/datastructures.py
@@ -293,13 +293,14 @@ class Reference:
         self.link = self.__clear_link(link)  # link itself
         self.line_number = line_number  # line number where ref occurs
         self.file_path = None  # full path of the file where ref occurs
+        self.pos_on_line = None  # position on line where ref occurs
 
     def get_file_name(self):
         return os.path.basename(self.file_path)
 
     @staticmethod
     def __clear_link(uri):
-        """This function removes the opening angle bracket from the beginning
+        """This method removes the opening angle bracket from the beginning
         of the link and closing angle bracket from the link end."""
         if not uri:
             return None
@@ -308,5 +309,27 @@ class Reference:
             uri = uri[1:]
         if uri.endswith('>'):
             uri = uri[:-1]
-        return uri
 
+        return Reference.__replace_end_of_lines(uri)
+
+    @staticmethod
+    def __replace_end_of_lines(uri):
+        """This method replaces the \n and \\n with spaces.
+        Note: This simulates the pandoc behavior for generating href attribute
+        for references."""
+        output = ""
+        i = 0
+        escape_next = False
+        while i < len(uri):
+            escape_next = True if uri[i] == "\\" and not escape_next else False
+            if escape_next and i < len(uri) - 1 and uri[i + 1] == "\n":
+                output += " "  # \\n is changed to space char
+                i += 1  # compensate the removed \n
+                escape_next = False
+            elif uri[i] == "\n":
+                output += " "  # replace \n with space char
+            else:
+                output += uri[i]  # every other character
+            i += 1
+
+        return output

--- a/MAGSBS/mparser/links.py
+++ b/MAGSBS/mparser/links.py
@@ -157,21 +157,21 @@ def get_text_inside_brackets(text):
     bracket_char = text[0]
     closing_bracket_char = brackets_dict[bracket_char]
 
-    procs = 1  # processed characters (bracket is already processed)
+    index = 1  # processed characters (bracket is already processed)
     count_brackets = 1  # counting brackets
     output = ""
     escape_next = False
 
-    while count_brackets > 0 and procs < len(text):
-        if text[procs] == bracket_char and not escape_next:
+    while count_brackets > 0 and index < len(text):
+        if text[index] == bracket_char and not escape_next:
             count_brackets += 1
-        if text[procs] == closing_bracket_char and not escape_next:
+        if text[index] == closing_bracket_char and not escape_next:
             count_brackets -= 1
-        escape_next = True if text[procs] == "\\" and not escape_next \
+        escape_next = True if text[index] == "\\" and not escape_next \
             else False
         if not escape_next:
-            output += text[procs]
-        procs += 1
+            output += text[index]
+        index += 1
 
     return procs, output[:-1]
 

--- a/MAGSBS/mparser/links.py
+++ b/MAGSBS/mparser/links.py
@@ -100,8 +100,8 @@ def extract_link(text):
     elif index < len(text) and text[index] == "(":  # inline links
         second_part = get_text_inside_brackets(text[index:])
         second_part_str = second_part[1]
-        if second_part_str.find(" ") != -1:
-            second_part_str = second_part_str[:second_part_str.find(" ")]
+        if second_part_str.find(r"\u0020") != -1:
+            second_part_str = second_part_str[:second_part_str.find(r"\u0020")]
         return index + second_part[0], Reference(
             Reference.Type.INLINE, image_char, identifier=first_part[1],
             link=second_part_str)
@@ -169,11 +169,18 @@ def get_text_inside_brackets(text):
             count_brackets -= 1
         escape_next = True if text[index] == "\\" and not escape_next \
             else False
-        if not escape_next:
+        # simulate the pandoc behaviour for \\n
+        if escape_next and index < len(text) - 1 and text[index + 1] == "\n":
+            output += " "  # \\n is changed to space char
+            index += 1  # compensate the removed \n
+            escape_next = False
+        elif text[index] == "\n":
+            output += " "  # replace \n with space char
+        else:
             output += text[index]
         index += 1
 
-    return procs, output[:-1]
+    return index, output[:-1]
 
 
 def is_todo_or_empty(reference):

--- a/MAGSBS/quality_assurance/linkchecker.py
+++ b/MAGSBS/quality_assurance/linkchecker.py
@@ -17,6 +17,10 @@ This link checker also checks for broken image references.
 
 This link checker does not touch the file system. It requires a list of files
 (as produced by os.walk()) and all links and images provided by LinkExtractor.
+
+Note: Checking of spaces between close square bracket and open parenthesis
+(e.g. [label] (link)) should not be detected by the LinkChecker, because it
+would cause many false positives.
 """
 
 import os


### PR DESCRIPTION
Linkchecker is now able to specify the position on the line of the reported link. The parser is slightly changed to support this functionality and I also fixed a bug. The ErrorMessage creation is also updated to support this functionality.

Moreover, the line end characters (\n and \\n) are currently removed from the links. This behavor is similar to pandoc when it creates the href attribute for tag <a>.  