### PR TITLE
Unnumbered headings - fix #62

### DIFF
--- a/MAGSBS/datastructures.py
+++ b/MAGSBS/datastructures.py
@@ -160,7 +160,7 @@ label "Heading" and attributes "{#id .class key=value}".
         self.__type = Heading.Type.NORMAL
         self.__chapter_number = None
 
-    def get_is_numbered(self):
+    def is_numbered(self):
         return self.__is_numbered
 
     def get_chapter_number(self):

--- a/MAGSBS/datastructures.py
+++ b/MAGSBS/datastructures.py
@@ -14,9 +14,16 @@ from . import roman
 
 CHAPTERNUM = re.compile(r'^[a-z|A-Z]+(\d\d).*\.md')
 
-def gen_id(text):
+def gen_id(text, attributes=None):
     """gen_id(text) -> an text for generating links.
-This function tries to generate the same text's as pandoc."""
+This function tries to generate the same text's as pandoc.
+If id is presented within list of attributes (in a form "#id"), than it is
+used for generation."""
+    if attributes: # generation of id if it is in the list of attributes
+        for attr in attributes:
+            if attr.startswith("#"):
+                return attr[1:]
+
     allowed_characters = ['.', '-', '_']
     text = text.lower()
     res_id = [] # does not contain double dash
@@ -146,7 +153,7 @@ label "Heading" and attributes "{#id .class key=value}".
         # detect if heading is numbered
         self.__is_numbered = detect_is_numbered(attributes)
         # id is generated from the parsed text
-        self.__id = gen_id(self.__text)
+        self.__id = gen_id(self.__text, attributes)
         self.__level = level
         self.__chapter_number = None
         self.__type = Heading.Type.NORMAL

--- a/MAGSBS/datastructures.py
+++ b/MAGSBS/datastructures.py
@@ -72,7 +72,7 @@ def is_attributes_repr(text):
     the attributes given by the PHP Markdown Extra syntax, available at
     https://michelf.ca/projects/php-markdown/extra/#spe-attr.
     Note: Shortcut {-} allowed by pandoc is also considered as correct
-    representation of attributes. """
+    representation of attribute. """
     if text == "-":
         return True  # shortcut for unnumbered given by pandoc
     regex = re.compile("^(#\w+\s*|\.\w+\s*|\w+=\w+\s*)+$")
@@ -117,7 +117,6 @@ def extract_label_and_attributes(text):
         return label, attributes
 
     attributes = label[start_index + 1: end_index].split()
-
     return (label[:start_index] + label[end_index + 1:]).rstrip(), attributes
 
 
@@ -131,6 +130,9 @@ class Heading:
     """heading(text, level)
 This class represents a heading to ease the handling of headings.
 For specifying the type of a heading, Heading.Type is used, which is an enum.
+Given text is parsed in the constructor - it is divided to the label of
+the heading and attributes. E.g. "Heading {#id .class key=value}" is parsed to
+label "Heading" and attributes "{#id .class key=value}".
 """
     class Type(enum.Enum):
         NORMAL = 0 # most headings are of that type

--- a/MAGSBS/datastructures.py
+++ b/MAGSBS/datastructures.py
@@ -19,7 +19,7 @@ def gen_id(text, attributes=None):
 This function tries to generate the same text's as pandoc.
 If id is presented within list of attributes (in a form "#id"), than it is
 used for generation."""
-    if attributes: # generation of id if it is in the list of attributes
+    if attributes:  # generation of id if it is in the list of attributes
         for attr in attributes:
             if attr.startswith("#"):
                 return attr[1:]
@@ -98,18 +98,18 @@ def extract_label_and_attributes(text):
         - e.g. {#identifier .class .class key=value key=value}.
     It returns the tuple. First part represents a label for heading (i.e.
     original text without extracted part that contains attributes). Second part
-    ot the tuple is a list of attributes (whitespaces are used as a
+    of the tuple is a list of attributes (whitespaces are used as a
     separators)."""
     attributes = []  # parsed attributes
     label = text.lstrip().rstrip()  # remove redundant whitespaces
     start_index = label.rfind("{")  # find last opening curly bracket
     # return same string in case, that text do not contain curly brackets or
     # if the last curly bracket is escaped by backslash
-    if start_index in {-1, 0}:
+    if start_index < 1:
         # curly bracket not find, is the fist non-whitespace char
         return label, attributes
 
-    # count number of backslashes
+    # count number of preceding backslashes
     backslash_counter = 0
     backslash_index = start_index - 1
     while backslash_index >= 0 and label[backslash_index] == "\\":

--- a/MAGSBS/toc.py
+++ b/MAGSBS/toc.py
@@ -277,7 +277,7 @@ the TOC corrrectly."""
 
         if heading.get_is_numbered():
             # when heading is numbered return it with number
-            return "[{}{}. {}]({}#{})".format(prefix,
+            return "[{}{} {}]({}#{})".format(prefix,
                 ".".join(map(str, chapter_number)), # (int, int...) -> str
                 heading.get_text(), path, heading.get_id())
 

--- a/MAGSBS/toc.py
+++ b/MAGSBS/toc.py
@@ -187,7 +187,7 @@ the TOC corrrectly."""
                     raise TypeError(("Internal error: Heading %s has incorrect"
                             " heading type %s\nFile: %s") % (heading.get_text(),
                                 repr(type(h_type)), os.path.join(directory_above, file)))
-                if heading.get_is_numbered():
+                if heading.is_numbered():
                     # only numbered headings are registered for numbering
                     enumerators[h_type].register(heading)
                 self.__headings[h_type].append((enumerators[h_type].get_heading_enumeration(),
@@ -274,7 +274,7 @@ the TOC corrrectly."""
         if '\\' in path:
             path = path.replace('\\', '/')
 
-        if heading.get_is_numbered():
+        if heading.is_numbered():
             # when heading is numbered return it with number
             return "[{}{} {}]({}#{})".format(prefix,
                 ".".join(map(str, chapter_number)), # (int, int...) -> str

--- a/MAGSBS/toc.py
+++ b/MAGSBS/toc.py
@@ -190,7 +190,6 @@ the TOC corrrectly."""
                 if heading.get_is_numbered():
                     # only numbered headings are registered for numbering
                     enumerators[h_type].register(heading)
-                enumerators[h_type].register(heading)
                 self.__headings[h_type].append((enumerators[h_type].get_heading_enumeration(),
                     heading, os.path.join(directory_above, file)))
 

--- a/MAGSBS/toc.py
+++ b/MAGSBS/toc.py
@@ -187,6 +187,9 @@ the TOC corrrectly."""
                     raise TypeError(("Internal error: Heading %s has incorrect"
                             " heading type %s\nFile: %s") % (heading.get_text(),
                                 repr(type(h_type)), os.path.join(directory_above, file)))
+                if heading.get_is_numbered():
+                    # only numbered headings are registered for numbering
+                    enumerators[h_type].register(heading)
                 enumerators[h_type].register(heading)
                 self.__headings[h_type].append((enumerators[h_type].get_heading_enumeration(),
                     heading, os.path.join(directory_above, file)))
@@ -271,9 +274,16 @@ the TOC corrrectly."""
         # replace \ through / on windows:
         if '\\' in path:
             path = path.replace('\\', '/')
-        return '[{}{}. {}]({}#{})'.format(prefix,
-                '.'.join(map(str, chapter_number)), # (int, int...) -> str
+
+        if heading.get_is_numbered():
+            # when heading is numbered return it with number
+            return "[{}{}. {}]({}#{})".format(prefix,
+                ".".join(map(str, chapter_number)), # (int, int...) -> str
                 heading.get_text(), path, heading.get_id())
 
-
+        # unnumbered headings don't have their number, so space is used only
+        # if prefix is used
+        space = " " if prefix else ""
+        return "[{}{}{}]({}#{})".format(prefix, space, heading.get_text(),
+                                        path, heading.get_id())
 

--- a/tests/test_mparser.py
+++ b/tests/test_mparser.py
@@ -611,21 +611,26 @@ class TestUnnumberedHeadings(unittest.TestCase):
         return heading.get_is_numbered()
 
     def test_head_label(self):
-        test_cases = ["# H 1 {.unnumbered}",
-                      "## H2\t\t\\\{-}",
-                      "# H3  {-",
-                      "### H4 {-}",  # "### Heading {} {-}"
-                      "# H5 {.class .unnumbered .differentclass}",
-                      "# H6 {# .differentclass .unnumbered}",
-                      # "# H6 {# .differentclass .unnumbered }",
-                      "# H7 {unnumbered}",
-                      "# H8 {# .different .unnumbered}"
-                      # r"# H9 \\{#id .unnumbered key=value\\}"]
-                      ]
+        test_cases = [
+            "H 1 {.unnumbered}", "H2\t\t\\\{-}", "H3  {-", "H4 {-}",
+            "H5 {.class .unnumbered .different}",
+            "H6 {# .differentclass .unnumbered}", "H7 {unnumbered}",
+            "H8 {# .different .unnumbered}", r"H9 \\{#id .unnumbered key=val}",
+            "H12 identifiers in HTML", "[HTML], [S5], or [RTF]?",
+            "3. Applications"]
+        # cases, which generate different identificators than pandoc
+        # format: test_case -> result (expected result)
+        # "H10  {}  {-}" -> "h10-" ("h10")
+        # "H12  {}  {-}" -> "h12-" ("h12")
+        # "H11 {# .class .unnumbered }" -> "h11-.class-.unnumbered-"
+        #       ("h11-.class-.unnumbered")
+        # "*Dogs*?--in *my* house?" -> "dogs--in-my-house" ("dogsin-my-house")
+
         outputs = ["h-1", "h2-", "h3--", "h4",
                    "h5", "h6-.differentclass-.unnumbered",
-                   "h7-unnumbered", "h8-.different-.unnumbered"]
-                   # ,"id"]
+                   "h7-unnumbered", "h8-.different-.unnumbered", "id",
+                   "h12-identifiers-in-html",
+                   "html-s5-or-rtf", "applications"]
 
         for i, case in enumerate(test_cases):
             heading = Heading(case, 0)

--- a/tests/test_mparser.py
+++ b/tests/test_mparser.py
@@ -594,3 +594,33 @@ class TestElementsIdsExtractor(unittest.TestCase):
             "<div class=\"test\" id=\"1\"/><span id='2_nd' test='test'/>"
             "<span middle='2_nd' id=\"middle\" test='test'/>")
         self.assertEqual(res, {"1", "2_nd", "middle"}, msg=self.out_msg(res))
+
+#  ###########################################################################
+
+
+class TestUnnumberedHeadings(unittest.TestCase):
+
+    @staticmethod
+    def out_msg(heading):
+        return "Unnumbered detection failed for heading {}".format(heading)
+
+    @staticmethod
+    def get_res(string):
+        pars = mp.file2paragraphs([string])
+        heading = mp.extract_headings_from_par(pars)[0]
+        return heading.get_is_numbered()
+
+    def test_numbered(self):
+        for case in ["# Heading 1", "# Heading 1 {#id}, ## Heading 2\t\t{#2}"]:
+            self.assertTrue(self.get_res(case), self.out_msg(case))
+
+    def test_unnumbered(self):
+        test_cases = ["# Heading 1 {.unnumbered}",
+                      "# Heading 1 {#id .unnumbered}",
+                      "## Heading 2\t\t{-}",
+                      "# Heading {-}",
+                      "### Heading {} {-}",
+                      "# Heading {#id .unnumbered .differentclass}",
+                      "# Heading {#id .differentclass .unnumbered }"]
+        for case in test_cases:
+            self.assertFalse(self.get_res(case), self.out_msg(case))

--- a/tests/test_mparser.py
+++ b/tests/test_mparser.py
@@ -608,7 +608,7 @@ class TestUnnumberedHeadings(unittest.TestCase):
     def get_res(string):
         pars = mp.file2paragraphs([string])
         heading = mp.extract_headings_from_par(pars)[0]
-        return heading.get_is_numbered()
+        return heading.is_numbered()
 
     def test_head_label(self):
         test_cases = [

--- a/tests/test_mparser.py
+++ b/tests/test_mparser.py
@@ -3,7 +3,7 @@ import unittest, sys, collections, os, itertools
 sys.path.insert(0, '.') # just in case
 import MAGSBS.errors as errors
 import MAGSBS.mparser as mp
-from MAGSBS.datastructures import Reference
+from MAGSBS.datastructures import Reference, Heading
 
 def parse_formulas(doc):
     """Tiny helper to call mp.parse_formulas."""
@@ -609,6 +609,27 @@ class TestUnnumberedHeadings(unittest.TestCase):
         pars = mp.file2paragraphs([string])
         heading = mp.extract_headings_from_par(pars)[0]
         return heading.get_is_numbered()
+
+    def test_head_label(self):
+        test_cases = ["# H 1 {.unnumbered}",
+                      "## H2\t\t\\\{-}",
+                      "# H3  {-",
+                      "### H4 {-}",  # "### Heading {} {-}"
+                      "# H5 {.class .unnumbered .differentclass}",
+                      "# H6 {# .differentclass .unnumbered}",
+                      # "# H6 {# .differentclass .unnumbered }",
+                      "# H7 {unnumbered}",
+                      "# H8 {# .different .unnumbered}"
+                      # r"# H9 \\{#id .unnumbered key=value\\}"]
+                      ]
+        outputs = ["h-1", "h2-", "h3--", "h4",
+                   "h5", "h6-.differentclass-.unnumbered",
+                   "h7-unnumbered", "h8-.different-.unnumbered"]
+                   # ,"id"]
+
+        for i, case in enumerate(test_cases):
+            heading = Heading(case, 0)
+            self.assertEqual(outputs[i], heading.get_id())
 
     def test_numbered(self):
         for case in ["# Heading 1", "# Heading 1 {#id}, ## Heading 2\t\t{#2}"]:


### PR DESCRIPTION
While creating headings, text is now parsed and attributes are obtained. Based on the attributes, it is decided, if the heading is numbered or not. Moreover, this is used for generating id. Minor changes are done also to toc.py file - register heading for numbering only if it is numbered and while generating output string for heading.

Note: There are some inconsistencies between gen_id function and pandoc generation. Those are addressed in mparser test file as comments (line 621 - 627). Maybe an issue for this could be created.