### PR TITLE
Feature/refactor

### DIFF
--- a/MAGSBS/master.py
+++ b/MAGSBS/master.py
@@ -112,4 +112,3 @@ files are converted."""
             conv.set_conversion_profile(self._profile)
             conv.convert_files(files_to_convert)
             os.chdir(orig_cwd)
-

--- a/MAGSBS/pandoc/converter.py
+++ b/MAGSBS/pandoc/converter.py
@@ -13,17 +13,13 @@ the field converters of the pandoc class.
 #pylint: disable=multiple-imports
 
 import os
-import re
-import pandocfilters
 from .formats import ConversionProfile, HtmlConverter
 from .. import config
 from ..config import MetaInfo
 from .. import common
-from . import contentfilter
 from .. import datastructures
 from .. import errors
 from .. import filesystem
-from .. import mparser
 
 
 def get_lecture_root(some_file):
@@ -50,12 +46,6 @@ class Pandoc:
 to the output, handles errors and checks for the correct encoding.
 The parameter `format` can be supplied to override the configured output format.
 """
-    # json content filters:
-    CONTENT_FILTERS = [contentfilter.page_number_extractor,
-                    contentfilter.suppress_captions]
-    # recognize chapter prefixes in paths, e.g. "anh01" for appendix chapter one
-    IS_CHAPTER = re.compile(r'^%s\d+\.md$' % '|'.join(common.VALID_FILE_BGN))
-
     def __init__(self, conf=None):
         self.converters = [HtmlConverter]
         self.__conf = (config.ConfFactory().get_conf_instance(os.getcwd())
@@ -104,76 +94,16 @@ The parameter `format` can be supplied to override the configured output format.
         return (cache, files)
 
     def convert_files(self, files):
-        """Convert a list of files. They should share all the meta data, except
+        """converts a list of files. They should share all the meta data, except
         for the title. All files must be part of one lecture.
         `files` can be either a cache object or a list of files to convert."""
         cache, files = self.__get_cache(files)
         converter = None # declare in outer scope for finally
-        try:
-            c = config.ConfFactory()
-            # configuration for current directory, directory changes, configuration might change too
-            conf = None
-            converter = None
-            for file_name in files:
-                # get correct configuration for each file
-                newconf = c.get_conf_instance(os.path.dirname(file_name))
-                # get new converter (and template) if config changes
-                if not newconf is conf:
-                    conf = newconf
-                    self.__update_metadata(conf)
-                    converter = self.get_formatter_for_format(conf[MetaInfo.Format])
-                    converter.set_meta_data(self.__meta_data)
-                    converter.setup()
-                    converter.set_profile(self.__conv_profile)
-                self.__convert_document(file_name, cache, converter, conf)
-        except errors.MAGSBS_error as e:
-            # set path for error
-            if not e.path:
-                e.path = os.path.abspath(file_name)
-            raise e
-        finally:
-            if converter:
-                converter.cleanup()
-
-    def __convert_document(self, path, file_cache, converter, conf):
-        """Convert a document by a given path. It takes a converter which takes
-        actual care of the underlying format. The filecache caches the list of
-        files in the lecture. The list of files within a lecture is required to
-        build navigation links.
-        This function also inserts a page navigation bar to navigate between
-        chapters and the table of contents."""
-        # if output file name exists and is newer than the original, it doesn need to be converted again
-        if not converter.needs_update(path):
-            return
-        with open(path, 'r', encoding='utf-8') as f:
-            document = f.read()
-        if not document:
-            return # skip empty documents
-        if self.IS_CHAPTER.search(os.path.basename(path)):
-            try:
-                nav_start, nav_end = generate_page_navigation(path, file_cache,
-                    mparser.extract_page_numbers_from_par(mparser.file2paragraphs(document)))
-            except errors.FormattingError as e:
-                e.path = path
-                raise e
-            document = '{}\n\n{}\n\n{}\n'.format(nav_start, document, nav_end)
-        json_ast = self.load_json(document)
-        # add MarkDown extensions with Pandoc filters
-        try:
-            filter = None
-            for filter in Pandoc.CONTENT_FILTERS:
-                json_ast = pandocfilters.walk(json_ast, filter,
-                        conf[MetaInfo.Format], [])
-            converter.convert(json_ast, path)
-        except KeyError as e: # API clash(?)
-            raise errors.StructuralError(("Incompatible Pandoc API found, while "
-                "applying filter %s (ABI clash?).\nKeyError: %s") % \
-                        (filter.__name__, str(e)), path)
-
-    def load_json(self, document):
-        """Load JSon input from ''inputf`` and return a reference to the loaded
-        json document tree."""
-        return contentfilter.text2json_ast(document)
+        converter = self.get_formatter_for_format(self.__conf[MetaInfo.Format])
+        converter.set_meta_data(self.__meta_data)
+        converter.setup()
+        converter.set_profile(self.__conv_profile)
+        converter.convert(files, cache=cache)
 
     def set_conversion_profile(self, profile):
         if not isinstance(profile, ConversionProfile):
@@ -184,51 +114,3 @@ The parameter `format` can be supplied to override the configured output format.
     def get_convert_profile(self):
         """Return profile for conversion"""
         return self.__conv_profile
-
-#pylint: disable=redefined-variable-type,too-many-locals
-def generate_page_navigation(file_path, file_cache, page_numbers, conf=None):
-    """generate_page_navigation(path, file_cache, page_numbers, conf=None)
-    Generate the page navigation for a page. The file path must be relative to
-    the lecture root. The file cache must be the datastructures.FileCache, the
-    page numbers must have the format of mparser.extract_page_numbers_from.
-    `conf=` should not be used, it is intended for testing purposes.
-    Returned is a tuple with the start and the end navigation bar. The
-    navigation bar itself is a string.
-    """
-    if not os.path.exists(file_path):
-        raise errors.StructuralError("File doesn't exist", file_path)
-    if not file_cache:
-        raise ValueError("Cache with values may not be None")
-    if not conf:
-        conf = config.ConfFactory().get_conf_instance(os.path.split(file_path)[0])
-    trans = config.Translate()
-    trans.set_language(conf[MetaInfo.Language])
-    relative_path = os.sep.join(file_path.rsplit(os.sep)[-2:])
-    previous, next = file_cache.get_neighbours_for(relative_path)
-    make_path = lambda path: '../{}/{}'.format(path[0], path[1].replace('.md',
-        '.' + conf[MetaInfo.Format]))
-    if previous:
-        previous = '[{}]({})'.format(trans.get_translation('previous').title(),
-                make_path(previous))
-    if next:
-        next = '[{}]({})'.format(trans.get_translation('next').title(), make_path(next))
-    navbar = []
-    page_numbers = [pnum for pnum in page_numbers
-        if (pnum.number % conf[MetaInfo.PageNumberingGap]) == 0] # take each pnumgapth element
-    if page_numbers:
-        navbar.append(trans.get_translation('pages').title() + ': ')
-        navbar.extend('[[{0}]](#p{0}), '.format(num) for num in page_numbers)
-        navbar[-1] = navbar[-1][:-2] # strip ", " from last chunk
-    navbar = ''.join(navbar)
-    chapternav = '[{}](../inhalt.{})'.format(trans.get_translation(
-            'table of contents').title(), conf[MetaInfo.Format])
-
-    if previous:
-        chapternav = previous + '  ' + chapternav
-    if next:
-        chapternav += "  " + next
-    # navigation at start of page
-    nav_start = '{0}\n\n{1}\n\n* * * *\n\n\n'.format(chapternav, navbar)
-    # navigation bar at end of page
-    nav_end = '\n\n* * * *\n\n{0}\n\n{1}\n'.format(navbar, chapternav)
-    return (nav_start, nav_end)

--- a/MAGSBS/pandoc/converter.py
+++ b/MAGSBS/pandoc/converter.py
@@ -164,8 +164,7 @@ The parameter `format` can be supplied to override the configured output format.
             for filter in Pandoc.CONTENT_FILTERS:
                 json_ast = pandocfilters.walk(json_ast, filter,
                         conf[MetaInfo.Format], [])
-            converter.convert(json_ast,
-                contentfilter.get_title(json_ast), path)
+            converter.convert(json_ast, path)
         except KeyError as e: # API clash(?)
             raise errors.StructuralError(("Incompatible Pandoc API found, while "
                 "applying filter %s (ABI clash?).\nKeyError: %s") % \
@@ -233,5 +232,3 @@ def generate_page_navigation(file_path, file_cache, page_numbers, conf=None):
     # navigation bar at end of page
     nav_end = '\n\n* * * *\n\n{0}\n\n{1}\n'.format(navbar, chapternav)
     return (nav_start, nav_end)
-
-

--- a/MAGSBS/pandoc/formats.py
+++ b/MAGSBS/pandoc/formats.py
@@ -102,7 +102,7 @@ General usage:
 # convert json of document and write it to basefilename + '.' + format; may
 # raises SubprocessError; the json is the Pandoc AST (intermediate file format)
 >>> if gen.needs_update(path):
-'''    ast = gen.convert(ast, title, path)
+'''    ast = gen.convert(ast, path)
 # clean up, e.g. deletion of templates. Should be executed even if gen.convert()
 # threw an error
 gen.cleanup()."""
@@ -126,10 +126,9 @@ gen.cleanup()."""
         """Set up converter."""
         pass
 
-    def convert(self, json_str, title, base_fn):
+    def convert(self, json_str, base_fn):
         """Read from JSON and return JSON, too.
         json_str: json representation of the documented, encoded as string
-        title: title of document
         path: path to file"""
         pass
 
@@ -218,13 +217,14 @@ class HtmlConverter(OutputGenerator):
                 _('You need to have Pandoc installed.'))
 
 
-    def convert(self, json_ast, title, path):
+    def convert(self, json_ast, path):
         """See super class documentation."""
         self.check_for_pandoc()
         dirname, filename = os.path.split(path)
         outputf = os.path.splitext(filename)[0] + '.' + self.FILE_EXTENSION
         pandoc_args = ['-s', '--template=%s' % self.template_path]
         # set title
+        title = contentfilter.get_title(json_ast)
         if title: # if not None
             pandoc_args += ['-V', 'pagetitle:' + title, '-V', 'title:' + title]
         # instruct pandoc to enumerate headings
@@ -349,5 +349,3 @@ def remove_temp(fn):
         except OSError:
             common.WarningRegistry().register_warning(
             "Couldn't remove tempfile", path=fn)
-
-

--- a/matuc/matuc_impl/__init__.py
+++ b/matuc/matuc_impl/__init__.py
@@ -641,4 +641,3 @@ def insert_line(lines, line_number, line):
         if lines[line_number+1].strip(): # no newline at end
             lines = lines[:line_number+1] + [''] + lines[line_number+1:]
     return lines
-

--- a/matuc_impl/__init__.py
+++ b/matuc_impl/__init__.py
@@ -641,4 +641,3 @@ def insert_line(lines, line_number, line):
         if lines[line_number+1].strip(): # no newline at end
             lines = lines[:line_number+1] + [''] + lines[line_number+1:]
     return lines
-


### PR DESCRIPTION
I basically moved stuff around.
All the stuff in converter.py might be dependent on the used filter. So I moved it to formats.py. Lots of other functions had to be moved, too because they are only needed in filters.py now.

Now it should be possible to call just convert_files with the files by the same interface.

I made the file cache a kwarg becaus I was not sure if it is needed by all future formats.

There is a function to update meta data in the object. It seems not to be needed.