### PR TITLE
removed output format from lecture configuration (fixes #75)

### DIFF
--- a/MAGSBS/config.py
+++ b/MAGSBS/config.py
@@ -95,7 +95,6 @@ def get_lnum_of_tag(path, tag):
 class MetaInfo(enum.Enum):
     AppendixPrefix = 'MAGSBS:appendixPrefix'
     Editor = 'dc:creator'
-    Format = 'dc:format'
     GenerateToc = 'MAGSBS:generateToc'
     Institution = 'dc:publisher'
     Language = 'dc:language'
@@ -133,9 +132,8 @@ instead.
     DEFAULTS = { MetaInfo.WorkingGroup: 'AG SBS', MetaInfo.Language: 'de',
             MetaInfo.Institution: 'TU Dresden',
             MetaInfo.Rights: 'Access limited to members',
-            MetaInfo.Format: 'html', MetaInfo.TocDepth: 5,
-            MetaInfo.AppendixPrefix: 0, MetaInfo.PageNumberingGap: 5,
-            MetaInfo.GenerateToc: 1}
+            MetaInfo.TocDepth: 5, MetaInfo.AppendixPrefix: 0,
+            MetaInfo.PageNumberingGap: 5, MetaInfo.GenerateToc: 1}
     NUMERICAL = (MetaInfo.TocDepth, MetaInfo.AppendixPrefix,
                 MetaInfo.PageNumberingGap, MetaInfo.GenerateToc)
 

--- a/MAGSBS/factories.py
+++ b/MAGSBS/factories.py
@@ -16,7 +16,7 @@ from .config import MetaInfo
 #pylint: disable=too-many-instance-attributes
 class ImageDescription():
     """
-ImageDescription(image_path)
+ImageDescription(image_path, file_extension)
 
 
 Store and format a picture description. It is important here to read all the
@@ -38,7 +38,7 @@ data is either a dictionary with keys 'internal' and 'external', where
 edited text, i.e. into the chapter, 'external' is meant to be included in the
 file containing outsourced image descriptions.
 """
-    def __init__(self, image_path):
+    def __init__(self, image_path, file_extension):
         self.__conf = config.ConfFactory().get_conf_instance( \
                 os.path.split(image_path)[0])
         l10N = config.Translate()
@@ -53,7 +53,7 @@ file containing outsourced image descriptions.
         self.__outsource_descriptions = False
         # maximum length of image description before outsourcing it
         self.img_maxlength = 100
-        self.__outsource_path = _('images') + '.' + self.__conf[MetaInfo.Format]
+        self.__outsource_path = _('images') + '.' + file_extension
 
     def set_description(self, desc):
         """Set alternative image description."""
@@ -119,4 +119,3 @@ file containing outsourced image descriptions.
                 title, '-' * len(title), self.__description)
         return {'internal': self.get_outsourcing_link(),
                 'external': external_text}
-

--- a/MAGSBS/factories.py
+++ b/MAGSBS/factories.py
@@ -16,7 +16,7 @@ from .config import MetaInfo
 #pylint: disable=too-many-instance-attributes
 class ImageDescription():
     """
-ImageDescription(image_path, file_extension)
+ImageDescription(image_path)
 
 
 Store and format a picture description. It is important here to read all the
@@ -38,7 +38,7 @@ data is either a dictionary with keys 'internal' and 'external', where
 edited text, i.e. into the chapter, 'external' is meant to be included in the
 file containing outsourced image descriptions.
 """
-    def __init__(self, image_path, file_extension):
+    def __init__(self, image_path, file_extension='html'):
         self.__conf = config.ConfFactory().get_conf_instance( \
                 os.path.split(image_path)[0])
         l10N = config.Translate()

--- a/MAGSBS/master.py
+++ b/MAGSBS/master.py
@@ -26,7 +26,7 @@ file so that we actually have multiple roots (a forest). This is necessary for
 lectures containing e.g. lecture and exercise material.  For each root the
 navigation bar and the table of contents is generated; afterwards all MarkDown
 files are converted."""
-    def __init__(self, path, profile):
+    def __init__(self, path, profile, output_format):
         if os.path.exists(path):
             if os.path.isfile(path):
                 raise OSError("Operation can only be applied to directories.")
@@ -35,6 +35,7 @@ files are converted."""
                     "on a whole lecture, not on particular chapters."), path)
         self._roots = self.__findroot(path)
         self._profile = profile
+        self._output_format = output_format
 
     def get_roots(self):
         return self._roots
@@ -101,7 +102,10 @@ files are converted."""
                 c.walk()
                 if not c.is_empty():
                     index = c.get_index()
-                    md_creator = toc.TocFormatter(index, ".")
+                    file_extension = pandoc.converter.get_file_extension(
+                        self._output_format.value
+                    )
+                    md_creator = toc.TocFormatter(index, ".", file_extension)
                     with open("inhalt.md", 'w', encoding="utf-8") as file:
                         file.write(md_creator.format())
 
@@ -110,5 +114,6 @@ files are converted."""
                     for dir, _, flist in filesystem.get_markdown_files(".", True)
                     for f in flist]
             conv.set_conversion_profile(self._profile)
+            conv.set_output_format(self._output_format)
             conv.convert_files(files_to_convert)
             os.chdir(orig_cwd)

--- a/MAGSBS/master.py
+++ b/MAGSBS/master.py
@@ -95,19 +95,17 @@ files are converted."""
         orig_cwd = os.getcwd()
         for root in self.get_roots():
             os.chdir(root)
-            conf = config.ConfFactory().get_conf_instance(".")
-            if conf[MetaInfo.GenerateToc]:
-                # create table of contents
-                c = toc.HeadingIndexer(".")
-                c.walk()
-                if not c.is_empty():
-                    index = c.get_index()
-                    file_extension = pandoc.converter.get_file_extension(
-                        self._output_format.value
-                    )
-                    md_creator = toc.TocFormatter(index, ".", file_extension)
-                    with open("inhalt.md", 'w', encoding="utf-8") as file:
-                        file.write(md_creator.format())
+            if self._output_format == pandoc.formats.OutputFormat.Html:
+                conf = config.ConfFactory().get_conf_instance(".")
+                if conf[MetaInfo.GenerateToc]:
+                    # create table of contents
+                    c = toc.HeadingIndexer(".")
+                    c.walk()
+                    if not c.is_empty():
+                        index = c.get_index()
+                        md_creator = toc.TocFormatter(index, ".")
+                        with open("inhalt.md", 'w', encoding="utf-8") as file:
+                            file.write(md_creator.format())
 
             conv = pandoc.converter.Pandoc()
             files_to_convert = [os.path.join(dir, f)

--- a/MAGSBS/pandoc/converter.py
+++ b/MAGSBS/pandoc/converter.py
@@ -41,20 +41,6 @@ def get_lecture_root(some_file):
             "for this file"), path)
 
 
-def get_file_extension(format_):
-    """Get converter file extension for a specific format."""
-    try: # get new instance
-        return next(filter(lambda converter: \
-                converter.PANDOC_FORMAT_NAME == format_,
-                ACTIVE_CONVERTERS)).FILE_EXTENSION
-    except StopIteration:
-        supported_formats = ', '.join(map(lambda c: c.PANDOC_FORMAT_NAME, \
-            ACTIVE_CONVERTERS))
-        raise NotImplementedError(("The configured format {} is not "
-            "supported at the moment. Supported formats: {}").format(
-            format, supported_formats))
-
-
 class Pandoc:
     """Abstract the translation by pandoc into a class which add meta-information
 to the output, handles errors and checks for the correct encoding.

--- a/MAGSBS/toc.py
+++ b/MAGSBS/toc.py
@@ -157,7 +157,7 @@ Take the ordered dict produced by HeadingIndexer() and transform it
 to a markdown file containing the formatted table of contents. With the
 specified path, the TocFormatter is able to fetch the configuration to format
 the TOC corrrectly."""
-    def __init__(self, index, path, file_extension):
+    def __init__(self, index, path, file_extension='html'):
         self.__index = index
         self.__path = path
         c = config.ConfFactory()

--- a/MAGSBS/toc.py
+++ b/MAGSBS/toc.py
@@ -157,7 +157,7 @@ Take the ordered dict produced by HeadingIndexer() and transform it
 to a markdown file containing the formatted table of contents. With the
 specified path, the TocFormatter is able to fetch the configuration to format
 the TOC corrrectly."""
-    def __init__(self, index, path):
+    def __init__(self, index, path, file_extension):
         self.__index = index
         self.__path = path
         c = config.ConfFactory()
@@ -167,6 +167,7 @@ the TOC corrrectly."""
                 HeadingType.PREFACE: []}
         if self.conf[MetaInfo.GenerateToc] == 1:
             self.build_index()
+        self.__file_extension = file_extension
 
     def build_index(self):
         """Walk through dictionary of file names and headings and create cache
@@ -214,7 +215,7 @@ the TOC corrrectly."""
 
         # if manual title page exists, link to it
         add_entry("titel.md", '[%s](titel.%s\n\n' % (_('title page').title(),
-                self.conf[MetaInfo.Format]))
+                self.__file_extension))
 
         if self.__headings[HeadingType.PREFACE]:
             output += self.format_section(_('preface').title(),
@@ -231,15 +232,15 @@ the TOC corrrectly."""
 
         add_entry('glossar.md',
                 '[{}](glossar.{})\\\n'.format(_('glossary').capitalize(),
-            self.conf[MetaInfo.Format]))
+            self.__file_extension))
         add_entry('index.md', '[{}](index.{})\\\n'.format(_('index').title(),
-            self.conf[MetaInfo.Format]))
+            self.__file_extension))
         add_entry('kurz.md', '[{}](kurz.{})\\\n'.format(
-                _('list of abbreviations').capitalize(), self.conf[MetaInfo.Format]))
+                _('list of abbreviations').capitalize(), self.__file_extension))
         add_entry('taktil.md', '[{}](taktil.{})\\\n'.format(
-                _('list of tactile graphics').capitalize(), self.conf[MetaInfo.Format]))
+                _('list of tactile graphics').capitalize(), self.__file_extension))
         add_entry('copyright.md', '[{}](copyright.{})\\\n'.format(
-                _('copyright notice').capitalize(), self.conf[MetaInfo.Format]))
+                _('copyright notice').capitalize(), self.__file_extension))
 
         if output[-1].endswith('\\\n'): # strip \\ from last line
             output[-1] = output[-1][:-2] + '\n'
@@ -247,7 +248,7 @@ the TOC corrrectly."""
         # include info.md, if it exists
         add_entry("info.md", ('\n\n* * * * *\n\n[{}](info.{})\n').format(
                 _("remarks about the accessible version").capitalize(),
-                self.conf[MetaInfo.Format]))
+                self.__file_extension))
         return ''.join(output) + '\n'
 
     def format_section(self, title, headings):
@@ -272,7 +273,7 @@ the TOC corrrectly."""
         prefix = ''
         if self.__use_appendix_prefix and heading.get_type() == HeadingType.APPENDIX:
             prefix = 'A.'
-        path = path.replace('.md', '.' + self.conf[MetaInfo.Format])
+        path = path.replace('.md', '.' + self.__file_extension)
         # replace \ through / on windows:
         if '\\' in path:
             path = path.replace('\\', '/')
@@ -288,4 +289,3 @@ the TOC corrrectly."""
         space = " " if prefix else ""
         return "[{}{}{}]({}#{})".format(prefix, space, heading.get_text(),
                                         path, heading.get_id())
-

--- a/matuc/matuc_impl.py
+++ b/matuc/matuc_impl.py
@@ -188,9 +188,6 @@ class main():
                   metavar="FILENAME", default='stdout')
         parser.add_argument('directory',
                 help='Input directory where search for headings is performed.')
-        parser.add_argument("-f", dest="format",
-                  help="select output format",
-                  metavar="FMT", default=None)
         options = parser.parse_args(args)
 
         file = None
@@ -207,11 +204,7 @@ class main():
             c = MAGSBS.toc.HeadingIndexer(directory)
             c.walk()
             if not c.is_empty():
-                from MAGSBS.pandoc.formats import OutputFormat
-                fmt = MAGSBS.toc.TocFormatter(c.get_index(),
-                        directory,
-                        (OutputFormat.Html if not options.format
-                            else OutputFormat.from_string(options.format)))
+                fmt = MAGSBS.toc.TocFormatter(c.get_index(), directory)
                 file.write(fmt.format())
                 if isinstance(file, io.StringIO):
                     file.seek(0)
@@ -338,9 +331,6 @@ sub-directory configurations or initialization of a new project."""
         parser.add_argument("-t", "--title", dest="title",
                 default=None,
                 help="set title for outsourced images (mandatory if outsourced)")
-        parser.add_argument("-f", dest="format",
-                  help="select output format",
-                  metavar="FMT", default=None)
         parser.add_argument('path', nargs="?", help="path to image file")
         options = parser.parse_args(args)
         if not options.path:
@@ -350,8 +340,7 @@ sub-directory configurations or initialization of a new project."""
             desc = sys.stdin.read()
         else:
             desc = options.description
-        img = MAGSBS.factories.ImageDescription(options.path,
-            MAGSBS.pandoc.formats.OutputFormat.from_string(options.format))
+        img = MAGSBS.factories.ImageDescription(options.path)
         img.set_description(desc)
         img.set_outsource_descriptions(options.outsource)
         if options.title:

--- a/tests/test_pandoc.py
+++ b/tests/test_pandoc.py
@@ -147,11 +147,11 @@ class TestNavbarGeneration(unittest.TestCase):
 
 
     def gen_nav(self, path, cache=None, pnums=None, conf=None):
+        h = get_html_converter()
         pnums = (pnums if pnums else self.pagenumbers)
-        return pandoc.formats.generate_page_navigation(path,
+        return h.generate_page_navigation(path,
                 (cache if cache else self.cache),
                 pnums,
-                'html',
                 conf=conf)
 
 
@@ -168,12 +168,13 @@ class TestNavbarGeneration(unittest.TestCase):
                 "page number 10 doesn't exist; got: " + repr(start))
 
     def test_that_roman_numbers_work(self):
+        h = get_html_converter()
         pnums = [datastructures.PageNumber('page', i, is_arabic=False) for i in
                 range(1, 20)]
         conf = {MetaInfo.Language : 'de', MetaInfo.PageNumberingGap: 5}
         path = 'k01/k01.md' # that has been initilized in the setup method
-        start, end = pandoc.formats.generate_page_navigation(path, self.cache,
-            pnums, 'html', conf=conf)
+        start, end = h.generate_page_navigation(path, self.cache,
+            pnums, conf=conf)
         self.assertTrue('[V]' in start+end,
             "Expected page number V in output, but couldn't be found: " + repr(start))
 

--- a/tests/test_pandoc.py
+++ b/tests/test_pandoc.py
@@ -41,7 +41,7 @@ class CleverTmpDir(tempfile.TemporaryDirectory):
     def __exit__(self, a, b, c):
         os.chdir(self.cwd)
         super().__exit__(a, b, c)
-        
+
 class test_HTMLConverter(unittest.TestCase):
     def setUp(self):
         self.original_directory = os.getcwd()
@@ -151,6 +151,7 @@ class TestNavbarGeneration(unittest.TestCase):
         return pandoc.formats.generate_page_navigation(path,
                 (cache if cache else self.cache),
                 pnums,
+                'html',
                 conf=conf)
 
 
@@ -160,8 +161,7 @@ class TestNavbarGeneration(unittest.TestCase):
         self.assertTrue(isinstance(start, str) and isinstance(end, str))
 
     def test_that_pnum_gap_is_used(self):
-        conf = {MetaInfo.Language: 'de', MetaInfo.PageNumberingGap: 10,
-        MetaInfo.Format: 'html'}
+        conf = {MetaInfo.Language: 'de', MetaInfo.PageNumberingGap: 10}
         start, end = self.gen_nav('k01/k01.md', conf=conf)
         self.assertTrue('[5]' not in start+end) # links to page 5 don't exist
         self.assertTrue('[10]' in start+end, # links to page 10 do exist
@@ -170,16 +170,15 @@ class TestNavbarGeneration(unittest.TestCase):
     def test_that_roman_numbers_work(self):
         pnums = [datastructures.PageNumber('page', i, is_arabic=False) for i in
                 range(1, 20)]
-        conf = {MetaInfo.Language : 'de', MetaInfo.PageNumberingGap: 5,
-        MetaInfo.Format: 'html'}
+        conf = {MetaInfo.Language : 'de', MetaInfo.PageNumberingGap: 5}
         path = 'k01/k01.md' # that has been initilized in the setup method
-        start, end = pandoc.formats.generate_page_navigation(path, self.cache, pnums, conf=conf)
+        start, end = pandoc.formats.generate_page_navigation(path, self.cache,
+            pnums, 'html', conf=conf)
         self.assertTrue('[V]' in start+end,
             "Expected page number V in output, but couldn't be found: " + repr(start))
 
     def test_that_language_is_used(self):
-        conf = {MetaInfo.Language: 'en', MetaInfo.PageNumberingGap: 5,
-        MetaInfo.Format: 'html'}
+        conf = {MetaInfo.Language: 'en', MetaInfo.PageNumberingGap: 5}
         start, end = map(str.lower, self.gen_nav('k01/k01.md', conf=conf))
         self.assertTrue('nhalt]' not in start+end)
         self.assertTrue('table of contents]' in start+end)
@@ -197,4 +196,3 @@ class TestNavbarGeneration(unittest.TestCase):
                 "none. However something makes this test believe that there is "
                 "actually another link. Here's the navigation bar: ") +
                 repr(start))
-


### PR DESCRIPTION
This pull request is a fix for issue #75 

the output format is removed from the lecture configuration. The configuration file must be updated manually accordingly.

The Format from the lecture configuration was used in many many places. In most of them just as file extension to write output files. I made the function _get_file_extension(format)_ in _converter.py_ which gets the file extension by output format name as it might be not the same.
Also I removed _get_convert_profile()_ from _converter.py_ as it is unused.

_generate_page_navigation(file_path, file_cache, page_numbers, file_extension, conf=None)_ in _formats.py_ uses an optional _conf_ parameter which is only used in the tests. It might be possible to get rid of it. Also it might be possible to add this function to a specific format as it might be different for other formats. I'm not sure yet though.