### PR TITLE
Epub support: Added appendix

### DIFF
--- a/MAGSBS/pandoc/contentfilter.py
+++ b/MAGSBS/pandoc/contentfilter.py
@@ -218,7 +218,7 @@ def epub_collect_link_targets(key, value, fmt, meta, modify_ast=True):
     meta stores all link IDs so it's possible to add the back links correctly.
     meta structure: { 'chapter': int, 'ids': dict }
     the 'ids' dict contains the ids of the links as key and the chapter as key"""
-    if fmt != 'epub' and not value:
+    if fmt != 'epub' or not value:
         return
     # if header level is 1 a new chapter is created for epub. It is needed
     # to count the chapters to create correct links.
@@ -282,6 +282,12 @@ def epub_create_back_links(key, value, fmt, meta):
         content.replaceChild(link, content.firstChild)
         return html(content.toxml())
 
+def epub_unnumbered_appendix_toc(key, value, fmt, meta, modify_ast=True):
+    """marks all headlines of appendix to be unnumbered in toc."""
+    if fmt != 'epub' or not value:
+        return
+    if key == 'Header':
+        value[1][1].append("unnumbered")  # append unnumbered class to header
 
 def suppress_captions(key, value, fmt, meta, modify_ast=True):
     """Images on a paragraph of its own get a caption, suppress that."""


### PR DESCRIPTION
Appendix gets now added between the content and the image descriptions.

The toc is now numbered except for the appendix.


It might be a good idea to add the _epub:type="appendix"_ to the section but pandox does add "data-" infront of the attribute to stay valide with html5. A possible solution would be to do it with a RawBlock. I'm not sure if this is needed because pandoc cannot add epub:type="backmatter" to the body tag because that one is only generated and not in the AST.