### PR TITLE
fixed link and anchor connection

### DIFF
--- a/MAGSBS/pandoc/contentfilter.py
+++ b/MAGSBS/pandoc/contentfilter.py
@@ -103,22 +103,20 @@ def epub_link_converter(key, value, fmt, meta, modify_ast=True):
     """Scan all links and append change to .html for all relative links."""
     if fmt != 'epub' or not value:
         return
-    # if header level is 1 a new chapter is created for epub. It is needed
-    # to count the chapters to create correct links.
-    if key == 'Header':
-        if value[0] == 1:  # first element contains header level (1 == <h1>)
-            meta['chapter'] += 1
-    elif key == 'Link':
+    if key == 'Link':
         link = value[-1][0]  # last element contains the actual link
         # filter out all absolute links
         if not link or LINK_REGEX.match(link):
             return
         if isinstance(link, str):
             link_parts = link.split('#', 1)  # split in # once
-            if not link_parts[0]:
+            if not link_parts[0] or not link_parts[1]:
                 return
-            link_parts[0] = 'ch{:03d}.xhtml'.format(meta['chapter'])
-            value[-1][0] = '#'.join(link_parts)
+            # check if id is in meta
+            if link_parts[1] in meta['ids']:
+                # set chapter from meta
+                link_parts[0] = 'ch{:03d}.xhtml'.format(meta['ids'][link_parts[1]])
+                value[-1][0] = '#'.join(link_parts)
 
 
 def epub_convert_header_ids(key, value, fmt, url_prefix, modify_ast=True):
@@ -212,19 +210,11 @@ def epub_update_image_location(key, value, fmt, url_prefix, modify_ast=True):
         value[-1][0] = '/'.join([url_prefix, image_url])  # dont use os.path
 
 
-def epub_collect_link_targets(key, value, fmt, meta, modify_ast=True):
-    """Collects all links via meta and appends an id to be used as anchor for
-    back buttons.
-    meta stores all link IDs so it's possible to add the back links correctly.
-    meta structure: { 'chapter': int, 'ids': dict }
-    the 'ids' dict contains the ids of the links as key and the chapter as key"""
+def epub_create_back_link_ids(key, value, fmt, meta, modify_ast=True):
+    """Adds an id with the suffix _back to each link to be used as anchor for
+    possible back links."""
     if fmt != 'epub' or not value:
         return
-    # if header level is 1 a new chapter is created for epub. It is needed
-    # to count the chapters to create correct links.
-    if key == 'Header':
-        if value[0] == 1:  # first element contains header level (1 == <h1>)
-            meta['chapter'] += 1
     # add an id to all relative links to jump back to
     elif key == 'Link':
         link = value[-1][0]  # last element contains the actual link
@@ -239,7 +229,6 @@ def epub_collect_link_targets(key, value, fmt, meta, modify_ast=True):
             link_parts = link.split('#', 1)  # split in # once
             if not link_parts[1]:
                 return
-            meta['ids'][link_parts[1]] = meta['chapter']
             value[0][0] = '{}_back'.format(link_parts[1])
 
 
@@ -247,7 +236,8 @@ def epub_create_back_links(key, value, fmt, meta):
     """creates back links for previously collected links.
     meta stores all link IDs so it's possible to add the back links correctly.
     meta structure: { 'chapter': int, 'ids': dict }
-    the 'ids' dict contains the ids of the links as key and the chapter as key"""
+    the 'ids' dict contains the ids of the links as key and
+    the chapter as key"""
     if fmt != 'epub':
         return
     # header from image descriptions are within a RawBlock 
@@ -268,19 +258,51 @@ def epub_create_back_links(key, value, fmt, meta):
         # check if the html code meets the requirements to be an image header
         if not all(x in content.attributes for x in ['id', 'class']):
             return
-        if not content.attributes['id'].value in meta['ids']:
+        anchor_id = content.attributes['id'].value + '_back'
+        if not anchor_id in meta['ids']:
             return
         # get the id to put it later in the link to go back
         # the original link will have a matching id
         # id: 'image_id' -> back link: '#image_id_back'
-        anchor_id = content.attributes['id'].value
         link = xml.createElement('a')
-        link.setAttribute('href', 'ch{:03d}.xhtml#{}_back'.format(
+        link.setAttribute('href', 'ch{:03d}.xhtml#{}'.format(
             meta['ids'][anchor_id], anchor_id))
         text = xml.createTextNode(content.firstChild.toxml())
         link.appendChild(text)
         content.replaceChild(link, content.firstChild)
         return html(content.toxml())
+
+
+def epub_collect_ids(key, value, fmt, meta):
+    """Collects IDs of all headers and links and stores them into meta['ids']
+    meta structure: { 'chapter': int, 'ids': dict }
+    the 'ids' dict contains the ids of the links as key and
+    the chapter as key"""
+    if fmt != 'epub' or not value:
+        return
+    # if header level is 1 a new chapter is created for epub. It is needed
+    # to count the chapters to create correct links.
+    if key == 'Header':
+        if value[0] == 1:  # first element contains header level (1 == <h1>)
+            meta['chapter'] += 1
+        # value[1][0] is id in AST for Header
+        meta['ids'][value[1][0]] = meta['chapter']
+    elif key == 'Link':
+        # value[0][0] is id in AST for Link
+        meta['ids'][value[0][0]] = meta['chapter']
+    elif key == 'RawBlock' and value[0] == 'html':
+        # get the html code from the raw block and parse it
+        xml = minidom.parseString(value[1])
+        # get the element to be updated
+        content = xml.getElementsByTagName("p")
+        if not content:
+            return
+        content = content[0]
+        # check if there is an id
+        if not 'id' in content.attributes:
+            return
+        meta['ids'][content.attributes['id'].value] = meta['chapter']
+
 
 def epub_unnumbered_appendix_toc(key, value, fmt, meta, modify_ast=True):
     """marks all headlines of appendix to be unnumbered in toc."""

--- a/MAGSBS/pandoc/output_formats/epub.py
+++ b/MAGSBS/pandoc/output_formats/epub.py
@@ -61,8 +61,9 @@ class EpubConverter(OutputGenerator):
     PANDOC_FORMAT_NAME = 'epub'
     FILE_EXTENSION = 'epub'
     CONTENT_FILTERS = [contentfilter.epub_page_number_extractor,
+                       contentfilter.epub_create_back_link_ids,
+                       contentfilter.epub_collect_ids,
                        contentfilter.epub_link_converter,
-                       contentfilter.epub_collect_link_targets,
                        contentfilter.epub_create_back_links]
     IMAGE_CONTENT_FILTERS = [contentfilter.epub_convert_image_header_ids,
                              contentfilter.epub_remove_images_from_toc]


### PR DESCRIPTION
It's using a more general and reliable approach now.

First all ids are collected from the ast where we can actually jump to. They are all stored in meta with the chapter where they were found. In the next step all links are scanned if the target is within the meta. If it is the link will be updated wih the correct chapter file which was previously stored in meta.