### PR TITLE
Added black config and reformatted code base

### DIFF
--- a/MAGSBS/config.py
+++ b/MAGSBS/config.py
@@ -7,7 +7,7 @@ MAGSBS-specific extensions.
 # details.
 #
 # (c) 2014-2018 Sebastian Humenda <shumenda |at| gmx |dot| de>
-#pylint: disable=line-too-long,too-few-public-methods
+# pylint: disable=line-too-long,too-few-public-methods
 
 import enum
 import datetime
@@ -22,66 +22,74 @@ from . import common
 from .errors import ConfigurationError
 from . import roman
 
-VERSION = StrictVersion('0.8')
+VERSION = StrictVersion("0.8")
 
 ## default values
 CONF_FILE_NAME = ".lecture_meta_data.dcxml"
 
 # all tokens which can mark a start of the page
-PAGENUMBERINGTOKENS = ['slide', 'folie', 'seite', 'page']
-PAGENUMBERINGTOKENS += [t.title() for t in PAGENUMBERINGTOKENS] # recognize with both case spellings
+PAGENUMBERINGTOKENS = ["slide", "folie", "seite", "page"]
+PAGENUMBERINGTOKENS += [
+    t.title() for t in PAGENUMBERINGTOKENS
+]  # recognize with both case spellings
 
 # regular expression to recognize page numbers, includes both arabic and roman
 # numbers
-ROMAN_NUMBER = re.compile(roman.roman_numeral_pattern_string.strip() \
-        .lstrip('^').rstrip('$'), re.VERBOSE)
-PAGENUMBERING_PATTERN = re.compile(r'''
+ROMAN_NUMBER = re.compile(
+    roman.roman_numeral_pattern_string.strip().lstrip("^").rstrip("$"), re.VERBOSE
+)
+PAGENUMBERING_PATTERN = re.compile(
+    r"""
         # recognize all different languages which are supported for the words
         # "slide" and "page"
         -\s*(%s)\s+
         (\d+|%s(?:-(?:\d+|%s))?)\s*- # arabic or roman numbers
-        ''' % ('|'.join(PAGENUMBERINGTOKENS), ROMAN_NUMBER.pattern,
-            ROMAN_NUMBER.pattern),
-        re.VERBOSE)
+        """
+    % ("|".join(PAGENUMBERINGTOKENS), ROMAN_NUMBER.pattern, ROMAN_NUMBER.pattern),
+    re.VERBOSE,
+)
 
 
-#pylint: disable=inconsistent-return-statements,protected-access
+# pylint: disable=inconsistent-return-statements,protected-access
 def get_semester():
     """Guess the current semester from the current time. Semesters are based on
     the German university system."""
     month = datetime.datetime.now().month
     year = datetime.datetime.now().year
     if month < 3 or month >= 9:
-        year = (year-1 if month < 3 else year) # WS starts at end of last year
-        return 'WS {}/{}'.format(year, year+1)
-    return 'SS {}'.format(year)
+        year = year - 1 if month < 3 else year  # WS starts at end of last year
+        return "WS {}/{}".format(year, year + 1)
+    return "SS {}".format(year)
 
 
 def get_lnum_of_tag(path, tag):
     """Find (xml) `tag` in `path` and return its line number. This function
     assumes one tag per line, as it is written by the LectureMetaData.write()
     method."""
-    tag = tag.replace('{http://purl.org/dc/elements/1.1}', ''). \
-            replace('{http://elvis.inf.tu-dresden.de}', 'MAGSBS:')
-    with open(path, 'r', encoding='utf-8') as f:
+    tag = tag.replace("{http://purl.org/dc/elements/1.1}", "").replace(
+        "{http://elvis.inf.tu-dresden.de}", "MAGSBS:"
+    )
+    with open(path, "r", encoding="utf-8") as f:
         for lnum, line in enumerate(f.readlines()):
             if tag in line:
                 return lnum + 1
 
+
 class MetaInfo(enum.Enum):
-    AppendixPrefix = 'MAGSBS:appendixPrefix'
-    Editor = 'dc:creator'
-    GenerateToc = 'MAGSBS:generateToc'
-    Institution = 'dc:publisher'
-    Language = 'dc:language'
-    LectureTitle = 'dc:title'
-    PageNumberingGap = 'MAGSBS:pageNumberingGap'
-    Rights = 'dc:rights'
-    SemesterOfEdit = 'dc:date'
-    Source = 'dc:source'
-    SourceAuthor = 'MAGSBS:sourceAuthor'
-    TocDepth = 'MAGSBS:tocDepth'
-    WorkingGroup = 'dc:contributor'
+    AppendixPrefix = "MAGSBS:appendixPrefix"
+    Editor = "dc:creator"
+    GenerateToc = "MAGSBS:generateToc"
+    Institution = "dc:publisher"
+    Language = "dc:language"
+    LectureTitle = "dc:title"
+    PageNumberingGap = "MAGSBS:pageNumberingGap"
+    Rights = "dc:rights"
+    SemesterOfEdit = "dc:date"
+    Source = "dc:source"
+    SourceAuthor = "MAGSBS:sourceAuthor"
+    TocDepth = "MAGSBS:tocDepth"
+    WorkingGroup = "dc:contributor"
+
 
 class LectureMetaData(dict):
     """The lecture conversion needs meta data which is then embedded into the HTML
@@ -105,13 +113,23 @@ Please note: you should not use this class, except if you can make sure that
 exactly one instance at a time exists for a given path. Use the ConfFactory
 instead.
 """
-    DEFAULTS = {MetaInfo.WorkingGroup: 'AG SBS', MetaInfo.Language: 'de',
-            MetaInfo.Institution: 'TU Dresden',
-            MetaInfo.Rights: 'Access limited to members',
-            MetaInfo.TocDepth: 5, MetaInfo.AppendixPrefix: 0,
-            MetaInfo.PageNumberingGap: 5, MetaInfo.GenerateToc: 1}
-    NUMERICAL = (MetaInfo.TocDepth, MetaInfo.AppendixPrefix,
-                MetaInfo.PageNumberingGap, MetaInfo.GenerateToc)
+
+    DEFAULTS = {
+        MetaInfo.WorkingGroup: "AG SBS",
+        MetaInfo.Language: "de",
+        MetaInfo.Institution: "TU Dresden",
+        MetaInfo.Rights: "Access limited to members",
+        MetaInfo.TocDepth: 5,
+        MetaInfo.AppendixPrefix: 0,
+        MetaInfo.PageNumberingGap: 5,
+        MetaInfo.GenerateToc: 1,
+    }
+    NUMERICAL = (
+        MetaInfo.TocDepth,
+        MetaInfo.AppendixPrefix,
+        MetaInfo.PageNumberingGap,
+        MetaInfo.GenerateToc,
+    )
 
     def __init__(self, file_path, version=VERSION):
         """Set default values."""
@@ -121,25 +139,27 @@ instead.
             if key in self.NUMERICAL:
                 super().__setitem__(key, 0)
             else:
-                super().__setitem__(key, 'Unknown')
+                super().__setitem__(key, "Unknown")
         for key, value in LectureMetaData.DEFAULTS.items():
             self[key] = value
-        if self[MetaInfo.Editor] == 'Unknown':
+        if self[MetaInfo.Editor] == "Unknown":
             # guess editor
-            if 'win32' in sys.platform or 'wind' in sys.platform:
+            if "win32" in sys.platform or "wind" in sys.platform:
                 import getpass
+
                 self[MetaInfo.Editor] = getpass.getuser()
-            else: # on unixoids, use pwd
+            else:  # on unixoids, use pwd
                 import pwd
+
                 if pwd.getpwuid(os.getuid())[4]:
                     editor = pwd.getpwuid(os.getuid())[4]
                 else:
-                    editor = pwd.getpwuid(os.getuid())[0] # login name
+                    editor = pwd.getpwuid(os.getuid())[0]  # login name
                 # on some systems, real name end with commas, strip those
                 while editor and not editor[-1].isalpha():
                     editor = editor[:-1]
                 self[MetaInfo.Editor] = editor
-        self[MetaInfo.SemesterOfEdit] = get_semester() # guess current semester
+        self[MetaInfo.SemesterOfEdit] = get_semester()  # guess current semester
         self.__changed = False
         self.__version = version
 
@@ -147,63 +167,73 @@ instead.
         """Write back configuration, if it was changed."""
         if not self.__changed:
             return
-        root = ET.Element('metadata')
-        root.attrib['xmlns:dc'] = 'http://purl.org/dc/elements/1.1'
-        root.attrib['xmlns:MAGSBS'] = 'http://elvis.inf.tu-dresden.de'
+        root = ET.Element("metadata")
+        root.attrib["xmlns:dc"] = "http://purl.org/dc/elements/1.1"
+        root.attrib["xmlns:MAGSBS"] = "http://elvis.inf.tu-dresden.de"
         for key, value in self.items():
-            if key.value.startswith('MAGSBS:'):
+            if key.value.startswith("MAGSBS:"):
                 c = ET.SubElement(root, key.value)
             else:
                 c = ET.SubElement(root, key.value)
             c.text = str(value)
         # add version number
-        c = ET.SubElement(root, 'MAGSBS:version')
+        c = ET.SubElement(root, "MAGSBS:version")
         c.text = str(self.__version)
         # re-format XML
-        out = minidom.parseString('<?xml version="1.0" encoding="UTF-8"?>' + \
-                ET.tostring(root, encoding="unicode")
-                ).toprettyxml(indent="  ", encoding="utf-8")
-        with open(self.__path, 'wb') as f:
+        out = minidom.parseString(
+            '<?xml version="1.0" encoding="UTF-8"?>'
+            + ET.tostring(root, encoding="unicode")
+        ).toprettyxml(indent="  ", encoding="utf-8")
+        with open(self.__path, "wb") as f:
             f.write(out)
 
     def get_path(self):
         return self.__path
 
     def read(self):
-        normalize_keys = lambda k: k.split(':')[-1] # strip namespace
+        normalize_keys = lambda k: k.split(":")[-1]  # strip namespace
         xmlkey2dict = {normalize_keys(key.value): key for key in MetaInfo}
 
-        with open(self.__path, 'r', encoding='utf-8') as data_source:
+        with open(self.__path, "r", encoding="utf-8") as data_source:
             root = ET.fromstring(data_source.read())
-            normalize_tag = lambda x: (x[x.find('}')+1:]  if '}' in x else x)
+            normalize_tag = lambda x: (x[x.find("}") + 1 :] if "}" in x else x)
             version_read = False
             for child in root:
                 tag = normalize_tag(child.tag)
-                if tag == 'version':
+                if tag == "version":
                     version_read = True
                     self.__check_for_version(self.__path, child.text)
                 elif not tag in xmlkey2dict:
-                    raise ConfigurationError(_("Unknown key %s, skipping. Please"
-                        " update the configuration and rerun the operation.") % tag,
-                            path=self.__path)
+                    raise ConfigurationError(
+                        _(
+                            "Unknown key %s, skipping. Please"
+                            " update the configuration and rerun the operation."
+                        )
+                        % tag,
+                        path=self.__path,
+                    )
                 else:
 
-                    key = xmlkey2dict[tag] # get enum
+                    key = xmlkey2dict[tag]  # get enum
                     value = child.text
                     if key in self.NUMERICAL:
                         try:
                             value = int(value)
                         except ValueError:
-                            raise ConfigurationError(_(f"Option {tag} "
-                                "has invalid, non-numerical value of {value}"),
-                                self.__path)
+                            raise ConfigurationError(
+                                _(
+                                    f"Option {tag} "
+                                    "has invalid, non-numerical value of {value}"
+                                ),
+                                self.__path,
+                            )
                     try:
                         self[key] = value
                     except IndexError:
-                        msg = _('Malformed XML in configuration: ') + ET.dump(child)
+                        msg = _("Malformed XML in configuration: ") + ET.dump(child)
                         raise ConfigurationError(msg, self.__path)
             if not version_read:
-                self.__check_for_version(self.__path, '0.1')
+                self.__check_for_version(self.__path, "0.1")
         self.__changed = False
 
     def __check_for_version(self, path, value):
@@ -211,33 +241,50 @@ instead.
         try:
             version = StrictVersion(value)
         except ValueError:
-            raise ConfigurationError(_("invalid version number: {}").format(repr(value),),
-                    path, line=get_lnum_of_tag(path, 'MAGSBS:version'))
+            raise ConfigurationError(
+                _("invalid version number: {}").format(repr(value),),
+                path,
+                line=get_lnum_of_tag(path, "MAGSBS:version"),
+            )
         # check whether the first two digits of the version numbers match;
         # that'll tread bug fix releases the same
         if self.__version.version[:2] == version.version[:2]:
-            if self.__version.version[-1] < version.version[-1]: # a newer bug fix release is available
-                common.WarningRegistry().register_warning(("A newer version of "
-                    "Matuc is available: ") + str(version))
+            if (
+                self.__version.version[-1] < version.version[-1]
+            ):  # a newer bug fix release is available
+                common.WarningRegistry().register_warning(
+                    ("A newer version of " "Matuc is available: ") + str(version)
+                )
             # do nothing
         elif version < self.__version:
             self.__changed = True
-            self.write() # overwrite version number in configuration which is too old
+            self.write()  # overwrite version number in configuration which is too old
         else:
-            raise ConfigurationError(_("Matuc is too old, the configuration "
-                "requires version {}, but version {} is running.").format(version, VERSION),
-                path, get_lnum_of_tag(path, 'MAGSBS:version'))
+            raise ConfigurationError(
+                _(
+                    "Matuc is too old, the configuration "
+                    "requires version {}, but version {} is running."
+                ).format(version, VERSION),
+                path,
+                get_lnum_of_tag(path, "MAGSBS:version"),
+            )
 
     def __setitem__(self, k, v):
         if not isinstance(k, MetaInfo):
-            raise ConfigurationError("Keys can only be of type MetaInfo, got " + \
-                    str(type(k)), path=self.get_path())
+            raise ConfigurationError(
+                "Keys can only be of type MetaInfo, got " + str(type(k)),
+                path=self.get_path(),
+            )
         if k in self.NUMERICAL:
             try:
                 v = int(v)
             except ValueError:
-                raise ConfigurationError(_("Option {} couldn't be converted to "
-                    "a number: {}").format(k, v), self.__path)
+                raise ConfigurationError(
+                    _("Option {} couldn't be converted to " "a number: {}").format(
+                        k, v
+                    ),
+                    self.__path,
+                )
         if k not in self.keys():
             raise ConfigurationError(_("the key %s is unknown") % k, self.__path)
         super().__setitem__(k, v)
@@ -261,6 +308,7 @@ The "corresponding" configuration (object) is selected using first the root
 configuration and then, if present, the corresponding subdirectory configuration
 (if in a subdirectory).
 """
+
     def __init__(self):
         self._instances = {}
 
@@ -274,7 +322,7 @@ configuration and then, if present, the corresponding subdirectory configuration
         returned."""
         if path is None:
             raise ValueError("Path expected")
-        elif path == '':
+        elif path == "":
             path = os.getcwd()
         if not os.path.exists(path):
             raise ConfigurationError("specified path doesn't exist", path)
@@ -296,8 +344,9 @@ configuration and then, if present, the corresponding subdirectory configuration
             except UnicodeDecodeError:
                 raise ValueError(_(f"{conf_path}: File must be encoded in UTF-8"))
             except ET.ParseError as e:
-                raise ConfigurationError(_("Configuration errorneous: ") + str(e),
-                        conf_path, e.position[0])
+                raise ConfigurationError(
+                    _("Configuration errorneous: ") + str(e), conf_path, e.position[0]
+                )
         return self._instances[conf_path]
 
     def get_conf_instance_safe(self, path):
@@ -319,80 +368,107 @@ class Translate:
 
     Custom translation class which can alter the language according to the set
     language. set_language raises ValueError if the language is unknown."""
-    supported_languages = ['de', 'fr', 'en']
+
+    supported_languages = ["de", "fr", "en"]
+
     def __init__(self):
         self.en_fr = {
-            "page": "page", "slide": "diapositive",
-            'preface':'introduction', 'appendix':'appendice',
-            'table of contents':'table des matières',
-            'chapters':'chapitres',
-            'description of image':"description à l'image",
-            'pages':'pages',
-            'external image description' : "description de l'image externe",
-            'next':'suivant', 'previous':'précédent',
-            'chapter':'chapitre', 'paper':'document',
-            'remarks about the accessible version':'remarques concernant la version accessible',
-            'note of editor': "Note de l'éditeur",
+            "page": "page",
+            "slide": "diapositive",
+            "preface": "introduction",
+            "appendix": "appendice",
+            "table of contents": "table des matières",
+            "chapters": "chapitres",
+            "description of image": "description à l'image",
+            "pages": "pages",
+            "external image description": "description de l'image externe",
+            "next": "suivant",
+            "previous": "précédent",
+            "chapter": "chapitre",
+            "paper": "document",
+            "remarks about the accessible version": "remarques concernant la version accessible",
+            "note of editor": "Note de l'éditeur",
             "title page": "couverture",
-            'glossary': 'glossaire',
-            'index': 'index',
-            'list of abbreviations': 'abréviations',
-            'list of tactile graphics': 'list de la graphiques tactiles',
-            'copyright notice': "avis de droit d'auteur",
-            'not edited': 'pas édité',
-            'end of frame': 'Fin cadre autour du texte',
-            'end of box': 'Fin de la bulle de texte'
+            "glossary": "glossaire",
+            "index": "index",
+            "list of abbreviations": "abréviations",
+            "list of tactile graphics": "list de la graphiques tactiles",
+            "copyright notice": "avis de droit d'auteur",
+            "not edited": "pas édité",
+            "end of frame": "Fin cadre autour du texte",
+            "end of box": "Fin de la bulle de texte",
         }
-        for colour, trans in {'black': ('noir', 'noire'),
-                'blue': ('bleu', 'bleue'), 'brown':('marron',)*2,
-                'grey': ('gris', 'grise'), 'green':('vert', 'verte'),
-                'orange':('orange',)*2, 'red':('rouge',)*2,
-                'violet':('violett', 'violette'), 'yellow':('jaune',)*2}.items():
+        for colour, trans in {
+            "black": ("noir", "noire"),
+            "blue": ("bleu", "bleue"),
+            "brown": ("marron",) * 2,
+            "grey": ("gris", "grise"),
+            "green": ("vert", "verte"),
+            "orange": ("orange",) * 2,
+            "red": ("rouge",) * 2,
+            "violet": ("violett", "violette"),
+            "yellow": ("jaune",) * 2,
+        }.items():
             masc, fem = trans
-            self.en_fr['%s frame' % colour] = 'Cadre {} autour du texte'\
-                    .format(masc)
-            self.en_fr['%s box' % colour] = 'Bulle {} de texte'.format(fem)
+            self.en_fr["%s frame" % colour] = "Cadre {} autour du texte".format(masc)
+            self.en_fr["%s box" % colour] = "Bulle {} de texte".format(fem)
 
-        self.en_de = {'preface':'vorwort', 'appendix':'anhang',
-                "page": "Seite", "slide": "Folie",
-            'table of contents' : 'inhaltsverzeichnis',
-            'chapters':'kapitel',
-            'description of image':'Beschreibung von Bild',
-            'pages':'Seiten',
-            'external image description':'Bildbeschreibung ausgelagert',
-            'next':'weiter', 'previous':'zurück',
-            'chapter':'kapitel', 'paper':'blatt',
-            'remarks about the accessible version':'Hinweise zur barrierefreien Version',
-            'note of editor': 'Anmerkung des Bearbeiters',
+        self.en_de = {
+            "preface": "vorwort",
+            "appendix": "anhang",
+            "page": "Seite",
+            "slide": "Folie",
+            "table of contents": "inhaltsverzeichnis",
+            "chapters": "kapitel",
+            "description of image": "Beschreibung von Bild",
+            "pages": "Seiten",
+            "external image description": "Bildbeschreibung ausgelagert",
+            "next": "weiter",
+            "previous": "zurück",
+            "chapter": "kapitel",
+            "paper": "blatt",
+            "remarks about the accessible version": "Hinweise zur barrierefreien Version",
+            "note of editor": "Anmerkung des Bearbeiters",
             "title page": "Titelseite",
-            'glossary': 'Glossar', 'index': 'index',
-            'list of abbreviations': 'Abkürzungsverzeichnis',
-            'list of tactile graphics': 'Verzeichnis taktiler Grafiken',
-            'copyright notice': 'Hinweise zum Urheberrecht',
-            'not edited': 'nicht Übertragen',
-            'end of frame': 'Rahmenende',
-            'end of box': 'Ende des Kastens', 'title': 'Titel',
-        } # insert colours
-        for colour, trans in {'black': 'schwarzer', 'blue': 'blauer',
-                'brown':'brauner', 'grey': 'grauer', 'green':'grüner',
-                'orange':'oranger', 'red':'roter', 'violet':'violetter',
-                'yellow':'gelber'}.items():
-            self.en_de['%s frame' % colour] = '{} Rahmen'.format(trans)
-            self.en_de['%s box' % colour] = '{} Kasten'.format(trans)
+            "glossary": "Glossar",
+            "index": "index",
+            "list of abbreviations": "Abkürzungsverzeichnis",
+            "list of tactile graphics": "Verzeichnis taktiler Grafiken",
+            "copyright notice": "Hinweise zum Urheberrecht",
+            "not edited": "nicht Übertragen",
+            "end of frame": "Rahmenende",
+            "end of box": "Ende des Kastens",
+            "title": "Titel",
+        }  # insert colours
+        for colour, trans in {
+            "black": "schwarzer",
+            "blue": "blauer",
+            "brown": "brauner",
+            "grey": "grauer",
+            "green": "grüner",
+            "orange": "oranger",
+            "red": "roter",
+            "violet": "violetter",
+            "yellow": "gelber",
+        }.items():
+            self.en_de["%s frame" % colour] = "{} Rahmen".format(trans)
+            self.en_de["%s box" % colour] = "{} Kasten".format(trans)
 
-        self.lang = 'de'
+        self.lang = "de"
 
     def set_language(self, lang):
         if not lang in self.supported_languages:
-            raise ValueError(_("unsupported language %s; known languages: %s") \
-                    % (lang, ', '.join(self.supported_languages)))
+            raise ValueError(
+                _("unsupported language %s; known languages: %s")
+                % (lang, ", ".join(self.supported_languages))
+            )
         self.lang = lang
 
     def get_translation(self, origin):
-        if self.lang == 'en':
+        if self.lang == "en":
             return origin
         try:
-            trans = getattr(self, 'en_' + self.lang)
+            trans = getattr(self, "en_" + self.lang)
         except AttributeError:
             return origin
         try:
@@ -402,4 +478,4 @@ class Translate:
 
     def get_translation_and_upper_first(self, origin):
         s = self.get_translation(origin)
-        return s[:1].upper() + s[1:] if s else ''
+        return s[:1].upper() + s[1:] if s else ""

--- a/MAGSBS/datastructures.py
+++ b/MAGSBS/datastructures.py
@@ -13,8 +13,9 @@ from . import common
 from . import errors
 from . import roman
 
-CHAPTERNUM = re.compile(r'^[a-z|A-Z]+(\d\d).*\.md')
+CHAPTERNUM = re.compile(r"^[a-z|A-Z]+(\d\d).*\.md")
 HEADING_ATTRIBUTES = re.compile("^(#\w+\s*|\.\w+\s*|\w+=\w+\s*)+$")
+
 
 def gen_id(text, attributes=None):
     """gen_id(text) -> label
@@ -26,14 +27,14 @@ used for generation and the text itself is ignored."""
             if attr.startswith("#"):
                 return attr[1:]
 
-    allowed_characters = ['.', '-', '_']
+    allowed_characters = [".", "-", "_"]
     text = text.lower()
-    res_id = [] # does not contain double dash
-    last_processed_char = ''
+    res_id = []  # does not contain double dash
+    last_processed_char = ""
     for char in text:
         # insert hyphen if it is space AND last char was not a space
         if char.isspace() and not last_processed_char.isspace():
-            res_id.append('-')
+            res_id.append("-")
         elif char.isalpha() or char.isdigit() or char in allowed_characters:
             res_id.append(char)
         else:
@@ -44,15 +45,16 @@ used for generation and the text itself is ignored."""
     # strip hyphens at the beginning, as well as numbers
     while res_id and not res_id[0].isalpha():
         res_id.pop(0)
-    return ''.join(res_id)
+    return "".join(res_id)
 
 
 def get_encoding():
     """Return encoding for stdin/stdout."""
-    encoding = sys.getdefaultencoding() # fallback
+    encoding = sys.getdefaultencoding()  # fallback
     if hasattr(sys.stdout, encoding) and sys.stdout.encoding:
         encoding = sys.stdout.encoding
     return encoding
+
 
 def decode(in_bytes):
     """Safe version to decode data from subprocesses."""
@@ -62,6 +64,7 @@ def decode(in_bytes):
         encodings = [get_encoding()]
         # add some more:
         import locale
+
         if not locale.getdefaultlocale()[1] in encodings:
             encodings.insert(0, locale.getdefaultlocale()[1])
         output = None
@@ -72,7 +75,7 @@ def decode(in_bytes):
             except UnicodeDecodeError:
                 pass
         if not output:
-            output = in_bytes.decode("utf-8", errors='ignore')
+            output = in_bytes.decode("utf-8", errors="ignore")
         return output
 
 
@@ -121,12 +124,15 @@ def extract_label_and_attributes(text):
         return label, attributes
 
     end_index = label.find("}", start_index + 1)
-    if end_index == -1 or end_index != len(label) - 1 or \
-            not is_attributes(label[start_index + 1: end_index]):
+    if (
+        end_index == -1
+        or end_index != len(label) - 1
+        or not is_attributes(label[start_index + 1 : end_index])
+    ):
         return label, attributes
 
-    attributes = label[start_index + 1: end_index].split()
-    return (label[:start_index] + label[end_index + 1:]).rstrip(), attributes
+    attributes = label[start_index + 1 : end_index].split()
+    return (label[:start_index] + label[end_index + 1 :]).rstrip(), attributes
 
 
 def detect_is_numbered(attributes):
@@ -144,8 +150,9 @@ Given text is parsed in the constructor - it is divided to the label of
 the heading and attributes. E.g. "Heading {#id .class key=value}" is parsed to
 label "Heading" and attributes "{#id .class key=value}".
 """
+
     class Type(enum.Enum):
-        NORMAL = 0 # most headings are of that type
+        NORMAL = 0  # most headings are of that type
         APPENDIX = 1
         PREFACE = 2
 
@@ -217,20 +224,23 @@ def extract_chapter_number(path):
     The path is optional, only the file name is required, but as shown above
     both is fine. If the file name does not follow naming conventions, a
     StructuralError is raised."""
-    match = re.search(r'^(?:[a-z|A-Z]+)(\d+)\.md$', os.path.basename(path))
+    match = re.search(r"^(?:[a-z|A-Z]+)(\d+)\.md$", os.path.basename(path))
     if not match or len(match.groups()[0]) < 2:
-        raise errors.StructuralError(_("the file does not follow naming "
-                "conventions"), path)
+        raise errors.StructuralError(
+            _("the file does not follow naming " "conventions"), path
+        )
     return int(match.groups()[0][:2])
 
 
 class FileHeading(Heading):
     """Heading which extracts chapter number and heading type from given file
     name. File name may not be a path but only the file name"""
+
     def __init__(self, text, level, file_name):
         super().__init__(text, level)
         self.__file_name = file_name
-        def startswith(string, lst): # does str starts with one item of list?
+
+        def startswith(string, lst):  # does str starts with one item of list?
             for token in lst:
                 if string.startswith(token):
                     return True
@@ -243,10 +253,12 @@ class FileHeading(Heading):
         elif startswith(file_name, common.VALID_APPENDIX_BGN):
             super().set_type(Heading.Type.APPENDIX)
         else:
-            raise ValueError("Couldn't extract heading type from '{}'". \
-                    format(file_name))
+            raise ValueError(
+                "Couldn't extract heading type from '{}'".format(file_name)
+            )
 
         self.set_chapter_number(extract_chapter_number(file_name))
+
 
 class FileCache:
     """FileCache(files)
@@ -264,7 +276,9 @@ class FileCache:
     >>> 'k01/k01.md' in f
     True
     """
-    CHAPTER_PREFIX = re.compile(r'^([A-Z|a-z]+)\d+.*')
+
+    CHAPTER_PREFIX = re.compile(r"^([A-Z|a-z]+)\d+.*")
+
     def __init__(self, file_list):
         # initialize three "caches" for the file names
         self.__main, self.__preface, self.__appendix = [], [], []
@@ -275,13 +289,17 @@ class FileCache:
         for directory, _, files in file_list:
             relative_dirname = os.path.basename(directory)
             for file in files:
-                if not file.endswith('.md'):
+                if not file.endswith(".md"):
                     continue
                 prefix = self.CHAPTER_PREFIX.search(file)
                 if not prefix:
-                    raise errors.StructuralError(("The file must be in the "
-                        "following format: <chapter_prefix><chapter_number>.md"),
-                        os.path.join(directory, file))
+                    raise errors.StructuralError(
+                        (
+                            "The file must be in the "
+                            "following format: <chapter_prefix><chapter_number>.md"
+                        ),
+                        os.path.join(directory, file),
+                    )
                 prefix = prefix.groups()[0]
                 if prefix in common.VALID_PREFACE_BGN:
                     self.__preface.append((relative_dirname, file))
@@ -290,8 +308,10 @@ class FileCache:
                 elif prefix in common.VALID_APPENDIX_BGN:
                     self.__appendix.append((relative_dirname, file))
                 else:
-                    raise errors.StructuralError(("The chapter prefix %s is "
-                        "unknown") % prefix, os.path.join(directory, file))
+                    raise errors.StructuralError(
+                        ("The chapter prefix %s is " "unknown") % prefix,
+                        os.path.join(directory, file),
+                    )
         self.__preface.sort()
         self.__main.sort()
         self.__appendix.sort()
@@ -299,8 +319,9 @@ class FileCache:
     def __contains__(self, file):
         """Return whether a given file is contained in the cache."""
         fns = lambda x: [dir_and_file[1] for dir_and_file in x]
-        return os.path.split(file)[1] in (fns(self.__main) + fns(self.__preface)
-                + fns(self.__appendix))
+        return os.path.split(file)[1] in (
+            fns(self.__main) + fns(self.__preface) + fns(self.__appendix)
+        )
 
     def get_neighbours_for(self, path):
         """Return neighbours of a given chapter. Path can be absolute (file
@@ -315,13 +336,13 @@ class FileCache:
         files = self.__preface + self.__main + self.__appendix
         for index, other_path in enumerate(files):
             if file_path == other_path:
-                previous = (files[index-1] if index > 0 else None)
-                succ = (files[index+1] if (index+1) < len(files) else None)
+                previous = files[index - 1] if index > 0 else None
+                succ = files[index + 1] if (index + 1) < len(files) else None
                 return (previous, succ)
         # if this code fragment is reached, file was not contained in list
-        raise errors.StructuralError(("The file was not found in the lecture. "
-            "This indicates a bug."), path)
-
+        raise errors.StructuralError(
+            ("The file was not found in the lecture. " "This indicates a bug."), path
+        )
 
 
 class PageNumber:
@@ -329,6 +350,7 @@ class PageNumber:
     string like "page" or "slide), a boolean arabic (if False, roman) and a
     number. Number can be a range, too. Optionally, the source code line number
     can be stored as well."""
+
     def __init__(self, identification, number, is_arabic=True):
         self.arabic = is_arabic
         self.identifier = identification
@@ -336,22 +358,23 @@ class PageNumber:
         self.line_no = None
 
     def __str__(self):
-        conv = (str if self.arabic else roman.to_roman)
+        conv = str if self.arabic else roman.to_roman
         if isinstance(self.number, range):
-            return '%s-%s' % (conv(self.number.start), conv(self.number.stop))
+            return "%s-%s" % (conv(self.number.start), conv(self.number.stop))
         else:
             return conv(self.number)
 
     def format(self):
         """Format this page number to a Markdown page number representation.
         Note: this is one of the MAGSBS-syntax extensions."""
-        return '|| - %s %s -' % (self.identifier, str(self))
+        return "|| - %s %s -" % (self.identifier, str(self))
 
 
 class Reference:
     """This class represents a reference to ease handling of the references.
     For specifying type of reference Reference.Type is used, which is an enum.
     """
+
     # Naming follows the pandoc user's guide at https://pandoc.org/MANUAL.html
     class Type(enum.Enum):
         INLINE = 0  # inline link in form [text](link)
@@ -359,9 +382,16 @@ class Reference:
         IMPLICIT = 2
         # ^ implicit reference link: [label][], [label] or [text][label]
 
-    #pylint: disable=too-many-arguments
-    def __init__(self, ref_type, is_image, identifier=None, link=None,
-                 is_footnote=False, line_number=None):
+    # pylint: disable=too-many-arguments
+    def __init__(
+        self,
+        ref_type,
+        is_image,
+        identifier=None,
+        link=None,
+        is_footnote=False,
+        line_number=None,
+    ):
 
         self.type = ref_type  # type of reference
         self.is_image = is_image  # True if reference represents an image
@@ -382,9 +412,9 @@ class Reference:
         if not uri:
             return None
 
-        if uri.startswith('<'):
+        if uri.startswith("<"):
             uri = uri[1:]
-        if uri.endswith('>'):
+        if uri.endswith(">"):
             uri = uri[:-1]
 
         return Reference.__replace_end_of_lines(uri)

--- a/MAGSBS/errors.py
+++ b/MAGSBS/errors.py
@@ -11,8 +11,10 @@ import collections
 import os
 import shlex
 
+
 class MAGSBS_error(Exception):
     """Just a parent."""
+
     def __init__(self, message, path=None, line=None, pos=None):
         self.message = message
         self.path = path
@@ -26,21 +28,24 @@ class MAGSBS_error(Exception):
         dictionary."""
         data = collections.OrderedDict()
         if self.path:
-            data['path'] = self.path
+            data["path"] = self.path
         if self.line:
-            data['line'] = self.line
-        if self.pos: # position on line
-            data['position'] = self.pos
-        data['message'] = self.message
+            data["line"] = self.line
+        if self.pos:  # position on line
+            data["position"] = self.pos
+        data["message"] = self.message
         if kwargs:
             data.update(kwargs)
         return data
 
     def __str__(self):
-        fmt = lambda b, pre: ('' if not b else '%s%s' % (pre, b))
-        pathlinepos = '%s%s%s' % (fmt(self.path, ''), fmt(self.line, ', '),
-                fmt(self.pos, ':'))
-        return '%s: %s' % (fmt(pathlinepos, ''), self.message)
+        fmt = lambda b, pre: ("" if not b else "%s%s" % (pre, b))
+        pathlinepos = "%s%s%s" % (
+            fmt(self.path, ""),
+            fmt(self.line, ", "),
+            fmt(self.pos, ":"),
+        )
+        return "%s: %s" % (fmt(pathlinepos, ""), self.message)
 
 
 class SubprocessError(MAGSBS_error):
@@ -54,17 +59,23 @@ class SubprocessError(MAGSBS_error):
     The error object will have attributes called command, message, path and line
     number (where the last may be None).
     """
+
     def __init__(self, command, message, path=os.getcwd(), line=None):
-        self.command = (' '.join(map(shlex.quote, command))
-                if isinstance(command, list) else command)
-        self.message = _('error while running: %s\n%s') % (self.command, message)
+        self.command = (
+            " ".join(map(shlex.quote, command))
+            if isinstance(command, list)
+            else command
+        )
+        self.message = _("error while running: %s\n%s") % (self.command, message)
         super().__init__(message)
         self.path = os.path.abspath(path)
         self.line = line
 
     def __str__(self):
-        return self.message.rstrip() + ('' if not self.path
-                else '\n  Path: ' + self.path)
+        return self.message.rstrip() + (
+            "" if not self.path else "\n  Path: " + self.path
+        )
+
 
 class ConfigurationError(MAGSBS_error):
     def __init__(self, message, path, line=None):
@@ -74,24 +85,28 @@ class ConfigurationError(MAGSBS_error):
         self.line = line
 
     def __str__(self):
-        prefix = ''
+        prefix = ""
         if self.path and os.path.exists(self.path):
-            prefix = (_('in configuration from') if os.path.isdir(self.path)
-                    else _('in configuration')) + ' '
-        return '{} {}: {}'.format(prefix, self.path, self.message)
+            prefix = (
+                _("in configuration from")
+                if os.path.isdir(self.path)
+                else _("in configuration")
+            ) + " "
+        return "{} {}: {}".format(prefix, self.path, self.message)
 
 
 class StructuralError(MAGSBS_error):
     """StructuralError(msg, path)
     Structural errors like wrong file name endings, wrong directory structures,
     etc."""
+
     def __init__(self, msg, path):
         self.message = msg
         super().__init__(msg)
         self.path = path
 
     def __str__(self):
-        msg = _('erroneous structure in %s: ') % self.path
+        msg = _("erroneous structure in %s: ") % self.path
         return msg + self.message
 
 
@@ -100,27 +115,34 @@ class FormattingError(MAGSBS_error):
     Report formatting error. It is adviced to provide a path, but it is not
     mandatory. The `excerpt` is used to show an example of where the formatting
     error occurred."""
+
     def __init__(self, msg, excerpt, path=None, line=None):
         self.excerpt = excerpt
         self.message = msg
-        super().__init__(msg + ':' + excerpt)
+        super().__init__(msg + ":" + excerpt)
         self.path = path
         self.line_no = line
 
     def __str__(self):
-        prefix = ''
+        prefix = ""
         if self.path:
-            prefix += _('error in {path}').format(self.path)
+            prefix += _("error in {path}").format(self.path)
         if self.line_no:
-            prefix += (' ' if prefix else '') + str(self.line_no)
-        return '%s%s%s\nExcerpt: %s' % (prefix, (': ' if prefix else ''),
-                self.message, self.excerpt)
+            prefix += (" " if prefix else "") + str(self.line_no)
+        return "%s%s%s\nExcerpt: %s" % (
+            prefix,
+            (": " if prefix else ""),
+            self.message,
+            self.excerpt,
+        )
+
 
 class MathError(MAGSBS_error):
-    #pylint: disable=too-many-arguments
-    def __init__(self, msg, formula, path=None, line=None, pos=None,
-            formula_count=None):
+    # pylint: disable=too-many-arguments
+    def __init__(
+        self, msg, formula, path=None, line=None, pos=None, formula_count=None
+    ):
         self.formula = formula
-        msg = '%s\n  %s' % (msg, formula)
+        msg = "%s\n  %s" % (msg, formula)
         super().__init__(msg, path=path, line=line, pos=pos)
         self.formula_count = formula_count

--- a/MAGSBS/factories.py
+++ b/MAGSBS/factories.py
@@ -13,8 +13,8 @@ from . import config
 from .config import MetaInfo
 
 
-#pylint: disable=too-many-instance-attributes
-class ImageDescription():
+# pylint: disable=too-many-instance-attributes
+class ImageDescription:
     """
 ImageDescription(image_path)
 
@@ -38,22 +38,24 @@ data is either a dictionary with keys 'internal' and 'external', where
 edited text, i.e. into the chapter, 'external' is meant to be included in the
 file containing outsourced image descriptions.
 """
-    def __init__(self, image_path, file_extension='html'):
-        self.__conf = config.ConfFactory().get_conf_instance( \
-                os.path.split(image_path)[0])
+
+    def __init__(self, image_path, file_extension="html"):
+        self.__conf = config.ConfFactory().get_conf_instance(
+            os.path.split(image_path)[0]
+        )
         l10N = config.Translate()
         l10N.set_language(self.__conf[MetaInfo.Language])
         self.__translate = _ = l10N.get_translation
         self.__image_path = image_path
         # replace \\ through / on windows
-        if sys.platform.lower().startswith('win') and os.sep in image_path:
-            self.__image_path = '/'.join(image_path.split(os.sep))
-        self.__description = '\n'
+        if sys.platform.lower().startswith("win") and os.sep in image_path:
+            self.__image_path = "/".join(image_path.split(os.sep))
+        self.__description = "\n"
         self.__title = None
         self.__outsource_descriptions = False
         # maximum length of image description before outsourcing it
         self.img_maxlength = 100
-        self.__outsource_path = _('images') + '.' + file_extension
+        self.__outsource_path = _("images") + "." + file_extension
 
     def set_description(self, desc):
         """Set alternative image description."""
@@ -77,22 +79,31 @@ file containing outsourced image descriptions.
     def get_outsourcing_link(self):
         """Return the link for the case that the picture is excluded."""
         _ = self.__translate
-        label = datastructures.gen_id( self.get_title() )
-        link_text = _('external image description')
-        return '[![%s](%s)](%s#%s)' % (link_text, self.__image_path,
-                self.get_outsource_path(), label)
+        label = datastructures.gen_id(self.get_title())
+        link_text = _("external image description")
+        return "[![%s](%s)](%s#%s)" % (
+            link_text,
+            self.__image_path,
+            self.get_outsource_path(),
+            label,
+        )
 
     def get_inline_description(self):
         """Generate markdown image with description."""
-        desc = self.__description.replace('\n',' ').replace('\r',' ').replace(' ',' ')
-        return '![%s](%s)' % (desc, self.__image_path)
+        desc = (
+            self.__description.replace("\n", " ").replace("\r", " ").replace(" ", " ")
+        )
+        return "![%s](%s)" % (desc, self.__image_path)
 
     def __get_outsourced_title(self):
         _ = self.__translate
         if not self.__title:
             # generate one from path
-            self.__title = _('description of image').capitalize() + " " + \
-                    os.path.split(self.__image_path)[1]
+            self.__title = (
+                _("description of image").capitalize()
+                + " "
+                + os.path.split(self.__image_path)[1]
+            )
             return self.__title
         else:
             return self.__title
@@ -103,7 +114,7 @@ file containing outsourced image descriptions.
         it'll depend on the description length."""
         if self.__outsource_descriptions:
             return True
-        return (True if len(self.__description) > self.img_maxlength else False)
+        return True if len(self.__description) > self.img_maxlength else False
 
     def get_output(self):
         """Dispatcher function for get_inline_description and
@@ -113,9 +124,9 @@ file containing outsourced image descriptions.
     description if set by set_outsource_descriptions(True) or will automatically
     exclude images longer than 100 characters."""
         if not self.will_be_outsourced():
-            return {'internal' : self.get_inline_description()}
+            return {"internal": self.get_inline_description()}
         title = self.__get_outsourced_title()
-        external_text = '{}\n{}\n\n{}\n\n* * * * *\n'.format(
-                title, '-' * len(title), self.__description)
-        return {'internal': self.get_outsourcing_link(),
-                'external': external_text}
+        external_text = "{}\n{}\n\n{}\n\n* * * * *\n".format(
+            title, "-" * len(title), self.__description
+        )
+        return {"internal": self.get_outsourcing_link(), "external": external_text}

--- a/MAGSBS/filesystem.py
+++ b/MAGSBS/filesystem.py
@@ -9,21 +9,24 @@ import os
 
 from . import config
 from .config import MetaInfo
-from.common import is_valid_file
+from .common import is_valid_file
 from . import errors
-#pylint: disable=redefined-builtin
 
-class FileWalker():
+# pylint: disable=redefined-builtin
+
+
+class FileWalker:
     """Abstraction class to provide functionality as offered by os.walk(), but
 omit certain files and folders.
 
 Ignored: folders like images, bilder, .git, .svn
 Files picked up: ending on configured file endings."""
+
     def __init__(self, path):
         if not os.path.exists(path):
             raise errors.StructuralError("Directory not found", path)
         self.path = path
-        self.black_list = ["quell",".svn",".git","bilder","images"]
+        self.black_list = ["quell", ".svn", ".git", "bilder", "images"]
         self.endings = ["md"]
         self.exclude_non_chapter_prefixed = True
 
@@ -31,8 +34,7 @@ Files picked up: ending on configured file endings."""
         self.black_list += new
 
     def set_endings(self, endings):
-        self.endings = [(e[1:] if e.startswith('.') else e)  for e in endings]
-
+        self.endings = [(e[1:] if e.startswith(".") else e) for e in endings]
 
     def set_ignore_non_chapter_prefixed(self, x):
         """Ignore files and directories which do not adhere to the common
@@ -43,44 +45,49 @@ Files picked up: ending on configured file endings."""
         """Returns true, if that directory shall be searched for files."""
         directory = os.path.split(directory)[-1]
         for bad in self.black_list:
-            if(directory.lower().startswith(bad)):
+            if directory.lower().startswith(bad):
                 return False
         return True
 
     def interesting_file(self, fn):
         """Filter against file endings."""
         for ending in self.endings:
-            if(fn.lower().endswith(ending)):
+            if fn.lower().endswith(ending):
                 return True
         return False
 
     def walk(self):
         if os.path.isfile(self.path):
             path, file = os.path.split(self.path)
-            if path == '':
-                path = '.'
+            if path == "":
+                path = "."
             return [(path, [], [file])]
         res = []
         dirs = [self.path]
         for dir in dirs:
-            if(dir == "."):
-                items = os.listdir( dir )
+            if dir == ".":
+                items = os.listdir(dir)
             else:
-                items = [os.path.join( dir, e)  for e in os.listdir( dir )]
-            files = sorted( [e for e in items \
-                        if os.path.isfile( e ) and self.interesting_file(e)])
-            newdirs = sorted( [e for e in items  if os.path.isdir( e )
-                        and self.interesting_dir(e)])
-            if(self.exclude_non_chapter_prefixed):
+                items = [os.path.join(dir, e) for e in os.listdir(dir)]
+            files = sorted(
+                [e for e in items if os.path.isfile(e) and self.interesting_file(e)]
+            )
+            newdirs = sorted(
+                [e for e in items if os.path.isdir(e) and self.interesting_dir(e)]
+            )
+            if self.exclude_non_chapter_prefixed:
                 # remove those which aren't starting with a common chapter prefix
-                files   = [e for e in files    if is_valid_file( e )]
-                newdirs = [e for e in newdirs  if is_valid_file( e )]
+                files = [e for e in files if is_valid_file(e)]
+                newdirs = [e for e in newdirs if is_valid_file(e)]
             dirs += newdirs
-            res.append((dir, [os.path.basename(e) for e in newdirs],
-                [os.path.basename( e )  for e in files]))
+            res.append(
+                (
+                    dir,
+                    [os.path.basename(e) for e in newdirs],
+                    [os.path.basename(e) for e in files],
+                )
+            )
         return res
-
-
 
 
 def get_markdown_files(dir, all_markdown_files=False):
@@ -94,6 +101,7 @@ definitions are listed, too."""
     fw.set_endings([".md"])
     return fw.walk()
 
+
 class InitLecture:
     """InitLecture()
 
@@ -106,7 +114,8 @@ builder.set_amount_appendix_chapters(2)
 builder.set_has_preface(True) # create preface chapter
 builder.generate_structure() # also inits a basic configuration
 """
-    def __init__(self, path, numOfChapters, lang='de'):
+
+    def __init__(self, path, numOfChapters, lang="de"):
         self.__lang = lang
         self.__amountChapters = numOfChapters
         self.__path = path
@@ -118,12 +127,12 @@ builder.generate_structure() # also inits a basic configuration
         self.__no_chapters = ex
 
     def set_amount_appendix_chapters(self, count):
-        if(not isinstance(count, int)):
+        if not isinstance(count, int):
             raise TypeError("Integer required.")
         self.__appendix_count = count
 
     def set_has_preface(self, preface):
-        if(not isinstance(preface, bool)):
+        if not isinstance(preface, bool):
             raise ValueError("Boolean required.")
         self.__preface = preface
 
@@ -135,29 +144,28 @@ new lecture root."""
         path = prefix + str(number).zfill(2)
         if not os.path.exists(path):
             os.mkdir(path)
-        chap_file = os.path.join(path, prefix + str(number).zfill(2)) + '.md'
-        with open(chap_file, 'w', encoding='utf-8') as f:
-            heading = _('chapter') + ' ' + str(number)
-            if self.__no_chapters: # use different heading
-                heading = _('paper') + ' ' + str(number)
+        chap_file = os.path.join(path, prefix + str(number).zfill(2)) + ".md"
+        with open(chap_file, "w", encoding="utf-8") as f:
+            heading = _("chapter") + " " + str(number)
+            if self.__no_chapters:  # use different heading
+                heading = _("paper") + " " + str(number)
             f.write(heading.capitalize())
-            f.write('\n')
-            f.write('=' * len(heading))
+            f.write("\n")
+            f.write("=" * len(heading))
             f.write("\n\n")
         if images_file:
-            imgpath = os.path.join(path, 'bilder.md')
-            with open(imgpath, 'w', encoding='utf-8') as f:
+            imgpath = os.path.join(path, "bilder.md")
+            with open(imgpath, "w", encoding="utf-8") as f:
                 f.write(_("image descriptions").capitalize())
                 f.write("\n")
-                f.write('=' * len(_("image descriptions")))
+                f.write("=" * len(_("image descriptions")))
                 f.write("\n\n")
-
 
     def generate_structure(self):
         """Create file system structure for the lecture, as configured.
 Initialize basic configuration as well."""
         if not os.path.exists(self.__path):
-            os.mkdir( self.__path )
+            os.mkdir(self.__path)
         cwd = os.getcwd()
         os.chdir(self.__path)
         # initialize configuration:
@@ -171,13 +179,12 @@ Initialize basic configuration as well."""
         _ = trans.get_translation
 
         if self.__preface:
-            self.__create_chapter('v', '1', False, _)
+            self.__create_chapter("v", "1", False, _)
         for index in range(1, self.__amountChapters + 1):
             if self.__no_chapters:
-                self.__create_chapter('blatt', index, False, _)
+                self.__create_chapter("blatt", index, False, _)
             else:
-                self.__create_chapter('k', index, False, _)
+                self.__create_chapter("k", index, False, _)
         for index in range(1, self.__appendix_count + 1):
-            self.__create_chapter('anh', index, False, _)
+            self.__create_chapter("anh", index, False, _)
         os.chdir(cwd)
-

--- a/MAGSBS/master.py
+++ b/MAGSBS/master.py
@@ -15,8 +15,7 @@ from . import pandoc
 from . import toc
 
 
-
-class Master():
+class Master:
     """m =Master(path)
 m.run()
 
@@ -26,15 +25,19 @@ file so that we actually have multiple roots (a forest). This is necessary for
 lectures containing e.g. lecture and exercise material.  For each root the
 navigation bar and the table of contents is generated; afterwards all MarkDown
 files are converted."""
+
     def __init__(self, path, profile, output_format):
         if os.path.exists(path):
             if os.path.isfile(path):
                 raise OSError("Operation can only be applied to directories.")
             if common.is_valid_file(os.path.abspath(path)):
                 raise errors.StructuralError(
-                        ("The master command can only be called "
-                        "on a whole lecture, not on particular chapters."),
-                    path)
+                    (
+                        "The master command can only be called "
+                        "on a whole lecture, not on particular chapters."
+                    ),
+                    path,
+                )
         self._roots = self.__findroot(path)
         self._profile = profile
         self._output_format = output_format
@@ -47,22 +50,27 @@ files are converted."""
         dirs = [path]
         go_deeper = True
         for directory in dirs:
-            meta = [e for e in os.listdir(directory) if e ==
-                    config.CONF_FILE_NAME]
-            if meta: # found, this is our root
+            meta = [e for e in os.listdir(directory) if e == config.CONF_FILE_NAME]
+            if meta:  # found, this is our root
                 roots.append(directory)
                 go_deeper = False
             else:
                 if go_deeper:
-                    dirs += [os.path.join(directory, e) \
-                            for e in os.listdir(directory) \
-                            if os.path.isdir(os.path.join(directory, e))]
-        found_md = any(fname.endswith(".md")
-            for directory, _, flist in os.walk(path)  for fname in flist)
+                    dirs += [
+                        os.path.join(directory, e)
+                        for e in os.listdir(directory)
+                        if os.path.isdir(os.path.join(directory, e))
+                    ]
+        found_md = any(
+            fname.endswith(".md")
+            for directory, _, flist in os.walk(path)
+            for fname in flist
+        )
         if not roots and found_md:
             # no root and markdown files present → lecture without configuration
-            raise errors.ConfigurationError(("no configuration found, but it "
-                "is required"), path)
+            raise errors.ConfigurationError(
+                ("no configuration found, but it " "is required"), path
+            )
         return roots
 
     def get_translation(self, word, path):
@@ -102,13 +110,15 @@ files are converted."""
                     if not c.is_empty():
                         index = c.get_index()
                         md_creator = toc.TocFormatter(index, ".")
-                        with open("inhalt.md", 'w', encoding="utf-8") as file:
+                        with open("inhalt.md", "w", encoding="utf-8") as file:
                             file.write(md_creator.format())
 
             conv = pandoc.converter.Pandoc(root_path=orig_cwd)
-            files_to_convert = [os.path.join(dir, f)
-                    for dir, _, flist in filesystem.get_markdown_files(".", True)
-                    for f in flist]
+            files_to_convert = [
+                os.path.join(dir, f)
+                for dir, _, flist in filesystem.get_markdown_files(".", True)
+                for f in flist
+            ]
             conv.set_conversion_profile(self._profile)
             conv.set_output_format(self._output_format)
             conv.convert_files(files_to_convert)

--- a/MAGSBS/matuc.py
+++ b/MAGSBS/matuc.py
@@ -8,7 +8,7 @@
 # This file contains the command-line frontend for the MAGSBS module, with a
 # user-friendly text interface. Most of the functionality is implemented in
 # matuc_impl, only the text formatter is defined here.
-#pylint: disable=multiple-imports
+# pylint: disable=multiple-imports
 
 
 import os
@@ -26,17 +26,21 @@ except (SystemError, ModuleNotFoundError):
     except ModuleNotFoundError:
         from MAGSBS import matuc_impl
 
+
 def get_terminal_size():
     """Get terminal size on GNU/Linux, default to 80 x 25 if not detectable."""
-    #pylint: disable=bare-except,multiple-imports
+    # pylint: disable=bare-except,multiple-imports
     env = os.environ
+
     def ioctl_GWINSZ(fd):
         try:
             import fcntl, termios, struct
-            cr = struct.unpack('hh', fcntl.ioctl(fd, termios.TIOCGWINSZ, '1234'))
+
+            cr = struct.unpack("hh", fcntl.ioctl(fd, termios.TIOCGWINSZ, "1234"))
         except:
             return
         return cr
+
     cr = ioctl_GWINSZ(0) or ioctl_GWINSZ(1) or ioctl_GWINSZ(2)
     if not cr:
         try:
@@ -46,35 +50,34 @@ def get_terminal_size():
         except:
             pass
         if not cr:
-            cr = (env.get('LINES', 25), env.get('COLUMNS', 80))
+            cr = (env.get("LINES", 25), env.get("COLUMNS", 80))
     return int(cr[1]), int(cr[0])
 
 
-
-def flatten(thing): # flatten a list of lists
+def flatten(thing):  # flatten a list of lists
     if isinstance(thing, list):
         for item in thing:
-            for whatever in flatten(item): yield whatever
+            for whatever in flatten(item):
+                yield whatever
     else:
         yield thing
-
 
 
 class TextFormatter(matuc_impl.OutputFormatter):
     def __init__(self):
         super().__init__()
-        self.spaces = lambda num: ' ' * num
+        self.spaces = lambda num: " " * num
 
     def __emit_warnings(self):
         """Emit warnings from the warning registry."""
-        reindent = lambda x: x.replace('\n', '\n  ')
+        reindent = lambda x: x.replace("\n", "\n  ")
         warnings = self.get_warnings()
         if warnings:
-            sys.stderr.write('Warnings:\n')
+            sys.stderr.write("Warnings:\n")
             data = []
             for warn in warnings:
-                data.append('  ' + reindent(MAGSBS.common.format_warning(warn)))
-            sys.stderr.write(''.join(data).rstrip() + '\n')
+                data.append("  " + reindent(MAGSBS.common.format_warning(warn)))
+            sys.stderr.write("".join(data).rstrip() + "\n")
 
     def _format_indented_line(self, line, prefix, indent):
         """Format a overlong line so that:
@@ -85,12 +88,13 @@ class TextFormatter(matuc_impl.OutputFormatter):
         """
         if line and not isinstance(line, str):
             line = str(line)
-        prefix = ' ' * indent + prefix
-        indent = indent + 2 # indent subsequent lines with indent + 2
-        t = textwrap.TextWrapper(width=get_terminal_size()[0] - indent,
-                initial_indent=prefix)
+        prefix = " " * indent + prefix
+        indent = indent + 2  # indent subsequent lines with indent + 2
+        t = textwrap.TextWrapper(
+            width=get_terminal_size()[0] - indent, initial_indent=prefix
+        )
         lines = t.wrap(line)
-        return [lines[0]] + ['\n{}{}'.format(' ' * indent, l) for l in lines[1:]]
+        return [lines[0]] + ["\n{}{}".format(" " * indent, l) for l in lines[1:]]
 
     def format_recursive(self, obj, indent):
         """Format a JSON-alike structure (dicts and lists containing dicts,
@@ -99,67 +103,75 @@ class TextFormatter(matuc_impl.OutputFormatter):
         if not obj:
             return []
         elif isinstance(obj, (str, bool, float, int)):
-            return self._format_indented_line(obj, '', indent) \
-                    + ['\n']
-        elif isinstance(obj, (list, tuple)): # format head of list, then tail
+            return self._format_indented_line(obj, "", indent) + ["\n"]
+        elif isinstance(obj, (list, tuple)):  # format head of list, then tail
             # avoid too deep recursion (is there a nicer solution?)
             data = []
             for item in obj:
                 data.append(self.format_recursive(item, indent))
             return data
         elif isinstance(obj, dict):
-            if 'verbatim' in obj: # do not format verbatim strings
-                return [' ' * indent, # reindent, but keep verbatim otherwise:
-                        ('\n' + ' ' * indent).join(obj['verbatim'].split('\n')),
-                        '\n']
+            if "verbatim" in obj:  # do not format verbatim strings
+                return [
+                    " " * indent,  # reindent, but keep verbatim otherwise:
+                    ("\n" + " " * indent).join(obj["verbatim"].split("\n")),
+                    "\n",
+                ]
             data = []
             for key, value in obj.items():
                 # no line break, display as key: value
                 if isinstance(value, (str, int, bool, float)):
-                    data += self._format_indented_line(str(value),
-                            key + ': ', indent) + ['\n']
-                else: # format key + \n + value (recursive)
-                    data += [' ' * (indent), key, ':', '\n']
+                    data += self._format_indented_line(
+                        str(value), key + ": ", indent
+                    ) + ["\n"]
+                else:  # format key + \n + value (recursive)
+                    data += [" " * (indent), key, ":", "\n"]
                     data += self.format_recursive(value, indent + 2)
             return data
 
     def emit_result(self, result):
         self.__emit_warnings()
-        text = ''.join(flatten(self.format_recursive(result, 0)))
+        text = "".join(flatten(self.format_recursive(result, 0)))
         try:
             print(text.rstrip())
         except UnicodeEncodeError as e:
             print("Error while printing non-ascii text: %s\n" % str(e))
-            print(text.encode('ascii', errors='ignore'))
+            print(text.encode("ascii", errors="ignore"))
 
     def emit_error(self, error):
         if isinstance(error, str):
-            error = {'verbatim': error}
+            error = {"verbatim": error}
         else:
-            message = error.pop('message')
-            error['message'] = {'verbatim': message}
-        error = {'error': error}
-        sys.stderr.write(''.join(flatten(self.format_recursive(error, 0))) + '\n')
+            message = error.pop("message")
+            error["message"] = {"verbatim": message}
+        error = {"error": error}
+        sys.stderr.write("".join(flatten(self.format_recursive(error, 0))) + "\n")
 
     def emit_usage(self, usage, error=None):
         if error:
-            if not error.lower().startswith('error'):
-                error = 'Error: ' + error
-            print(error.rstrip(), end='\n\n')
+            if not error.lower().startswith("error"):
+                error = "Error: " + error
+            print(error.rstrip(), end="\n\n")
         print(usage)
 
     def clear(self):
         """Clear the screen. There is no easy cross-platform way, so try to use
         cls/clear."""
-        if sys.platform.startswith('win'):
-            os.system('cmd /c cls')
-        elif shutil.which('clear'):
-            os.system('clear')
+        if sys.platform.startswith("win"):
+            os.system("cmd /c cls")
+        elif shutil.which("clear"):
+            os.system("clear")
         else:
             print("\n" + "-" * get_terminal_size()[0])
-            if 'linux' in sys.platform:
-                self.register_warning({'message': ("The `clear` command was not"
-                    " found, install it, i.e. with `apt-get install ncurses-bin`.")})
+            if "linux" in sys.platform:
+                self.register_warning(
+                    {
+                        "message": (
+                            "The `clear` command was not"
+                            " found, install it, i.e. with `apt-get install ncurses-bin`."
+                        )
+                    }
+                )
 
 
 def main():
@@ -167,5 +179,5 @@ def main():
     main_inst.run(sys.argv)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/MAGSBS/matuc_impl.py
+++ b/MAGSBS/matuc_impl.py
@@ -13,7 +13,7 @@ It provides:
 The actual output is formatted and printed using scripts called matuc and
 matuc_js. They share *all* of the functionality of this module and just define a
 text and a JSON interface."""
-#pylint: disable=invalid-name
+# pylint: disable=invalid-name
 from abc import ABCMeta, abstractmethod
 import argparse
 import collections
@@ -37,10 +37,11 @@ import MAGSBS.toc
 
 PROCNAME = os.path.basename(sys.argv[0])
 
-#necessary for function '_'
+# necessary for function '_'
 MAGSBS.common.setup_i18n()
 
-MAIN_USAGE = _("""%s <command> <options>
+MAIN_USAGE = _(
+    """%s <command> <options>
 
 <command> determines which action to take. The syntax might vary between
 commands. Use %s <command> -h for help.
@@ -57,7 +58,9 @@ new             - create new project structure
 mk              - invoke "mistkerl", a quality assurance helper
 toc             - generate table of contents
 version         - output program version
-""" % (PROCNAME, PROCNAME))
+"""
+    % (PROCNAME, PROCNAME)
+)
 
 
 class OutputFormatter:
@@ -72,13 +75,15 @@ class OutputFormatter:
     dictionary is ignored. Note: anything exporting to a JSON API must convert
     this special case of {'verbatim': 'something'} into 'something'. to be
     compliant with the JSON API specification."""
+
     __metaclass__ = ABCMeta
+
     @staticmethod
     def register_warning(warn):
         """A simple wrapper to pass the warning to the warning registry."""
-        if not hasattr('__getitem__'):
-            raise TypeError('Dictionary-alike object required')
-        if not 'message' in warn:
+        if not hasattr("__getitem__"):
+            raise TypeError("Dictionary-alike object required")
+        if not "message" in warn:
             raise ValueError("A warning must have a message.")
         MAGSBS.common.WarningRegistry().register_warning(warn)
 
@@ -109,10 +114,12 @@ class OutputFormatter:
         was supplied incorrectly. Both have to be of type string."""
         pass
 
+
 class HelpfulParser(argparse.ArgumentParser):
     """Unlike the super class, this arg parse instance will print the error it
     encountered as well as the complete usage of the program. It will also
     redirect the usage to a output formatter."""
+
     def __init__(self, name, output_formatter, description=None):
         self.formatter = output_formatter
         if description:
@@ -127,8 +134,8 @@ class HelpfulParser(argparse.ArgumentParser):
         else:
             buffer = file
         super().print_help(buffer)
-        if not file: # own buffer, write to emit_usage
-            buffer.seek(0) # jump back in logical stream
+        if not file:  # own buffer, write to emit_usage
+            buffer.seek(0)  # jump back in logical stream
             self.formatter.emit_usage(buffer.read())
 
     def error(self, message):
@@ -136,12 +143,14 @@ class HelpfulParser(argparse.ArgumentParser):
         buffer = io.StringIO()
         self.print_help(buffer)
         buffer.seek(0)
-        self.formatter.emit_usage(buffer.read(), error='Error: ' + message)
+        self.formatter.emit_usage(buffer.read(), error="Error: " + message)
         sys.exit(2)
 
-#pylint: disable=too-few-public-methods
+
+# pylint: disable=too-few-public-methods
 class ErrorHandler:
     """Contet handler to handle exceptions gracefully."""
+
     def __init__(self, output_formatter):
         self.output_formatter = output_formatter
 
@@ -150,21 +159,24 @@ class ErrorHandler:
 
     def __exit__(self, exc_type, exc_value, tb):
         import traceback
+
         error = {}
         if exc_type:
             if isinstance(exc_value, MAGSBS.errors.MAGSBS_error):
                 error = exc_value.to_json()
             else:
-                error['message'] = exc_type.__name__  + ': ' + str(exc_value)
-            if os.environ.get('DEBUG'):
-                error['traceback'] = {'verbatim':
-                        ''.join(traceback.format_exception(exc_type,
-                        exc_value, tb))}
+                error["message"] = exc_type.__name__ + ": " + str(exc_value)
+            if os.environ.get("DEBUG"):
+                error["traceback"] = {
+                    "verbatim": "".join(
+                        traceback.format_exception(exc_type, exc_value, tb)
+                    )
+                }
             self.output_formatter.emit_error(error)
             sys.exit(119)
 
 
-class main():
+class main:
     def __init__(self, output_formatter):
         self.output_formatter = output_formatter
 
@@ -174,11 +186,12 @@ class main():
         else:
             # try to get a handler for it
             try:
-                invokation_command = '%s %s' % (PROCNAME, sys.argv[1])
-                func = getattr(self, 'handle_%s' % args[1])
+                invokation_command = "%s %s" % (PROCNAME, sys.argv[1])
+                func = getattr(self, "handle_%s" % args[1])
             except AttributeError:
-                self.output_formatter.emit_usage(MAIN_USAGE,
-                        _("Invalid command: %s" % args[1]))
+                self.output_formatter.emit_usage(
+                    MAIN_USAGE, _("Invalid command: %s" % args[1])
+                )
                 sys.exit(127)
             ret = func(invokation_command, args[2:])
             if not ret:
@@ -187,24 +200,32 @@ class main():
 
     def handle_toc(self, cmd, args):
         "Table Of Contents"
-        parser = HelpfulParser(cmd, self.output_formatter,
-                description=_("Generate table of contents."))
-        parser.add_argument("-o", "--output", dest="output",
-                  help=_("write output to file instead of stdout"),
-                  metavar="FILENAME", default='stdout')
-        parser.add_argument('directory',
-                help=_('material directory (containing chapters)'))
+        parser = HelpfulParser(
+            cmd, self.output_formatter, description=_("Generate table of contents.")
+        )
+        parser.add_argument(
+            "-o",
+            "--output",
+            dest="output",
+            help=_("write output to file instead of stdout"),
+            metavar="FILENAME",
+            default="stdout",
+        )
+        parser.add_argument(
+            "directory", help=_("material directory (containing chapters)")
+        )
         options = parser.parse_args(args)
 
         file = None
-        if options.output == 'stdout':
+        if options.output == "stdout":
             file = io.StringIO()
         else:
-            file = open(options.output, 'w', encoding='utf-8')
+            file = open(options.output, "w", encoding="utf-8")
         directory = options.directory
         if not os.path.exists(directory):
-            self.output_formatter.emit_error(("Directory %s does not exist") \
-                    % directory)
+            self.output_formatter.emit_error(
+                ("Directory %s does not exist") % directory
+            )
             sys.exit(126)
 
         with ErrorHandler(self.output_formatter):
@@ -215,13 +236,14 @@ class main():
                 file.write(fmt.format())
                 if isinstance(file, io.StringIO):
                     file.seek(0)
-                    self.output_formatter.emit_result({'verbatim': file.read()})
+                    self.output_formatter.emit_result({"verbatim": file.read()})
                 else:
                     file.close()
 
     def handle_conf(self, cmd, args):
         """Create or update configuration."""
-        description = _("""Allowed subcommands are `show`, `update` and `init`.
+        description = _(
+            """Allowed subcommands are `show`, `update` and `init`.
 `show` shows the current configuration settings, default values if none present.
 `update` and `show` try to find the correct configuration: if none exists in the
 current directory and you are in a subdirectory of a project, the project root
@@ -230,51 +252,96 @@ are displayed.
 
 `init` on the other hand behaves basically like update (it sets configuration
 values), but it does that for the current directory. This is handy for
-sub-directory configurations or initialization of a new project.""")
+sub-directory configurations or initialization of a new project."""
+        )
         parser = HelpfulParser(cmd, self.output_formatter, description)
-        parser.add_argument("-a", dest="AppendixPrefix",
-                  help=_('insert "A" as prefix for each chapter number in the '
-                          'appendix and omit the header "appendix"'),
-                  action="store_true", default=False)
-        parser.add_argument("-A", dest="SourceAuthor",
-                  help=_('set author of source document'))
-        parser.add_argument("-e", dest="Editor",
-                  help=_('set project editor'),
-                  metavar="NAME", default=None)
-        parser.add_argument("-i", dest="Institution",
-                  help=_('set institution (default TU Dresden)'),
-                  metavar="NAME", default=None)
-        parser.add_argument("-l", dest="LectureTitle",
-                  help=_('set title of project (first heading level 1 by '
-                      'default)'),
-                  metavar="TITLE", default=None)
-        parser.add_argument("-L", dest='Language',
-                  help=_('set document language (de by default)'),
-                  default='de')
-        parser.add_argument("-p", "--pnum-gap", dest="PageNumberingGap",
-                  help=_('specify gap between page numbering links in '
-                      'navigation bar (default: 5)'),
-                  metavar="NUM", default=None)
-        parser.add_argument("-s", dest="Source",
-                  help=_('set information about source document'),
-                  metavar="SRC", default=None)
-        parser.add_argument("-S", dest="SemesterOfEdit",
-                  help=_('set semester of edit (will be guessed otherwise)'),
-                  metavar="SEMYEAR", default=None)
-        parser.add_argument("--toc-depth", dest="TocDepth",
-                  help=_('limit the heading depth for the table of contents'),
-                  metavar="NUM", default=None)
-        parser.add_argument("-w", dest="WorkingGroup",
-                  help=_('set working group'),
-                  metavar="GROUP", default=None)
+        parser.add_argument(
+            "-a",
+            dest="AppendixPrefix",
+            help=_(
+                'insert "A" as prefix for each chapter number in the '
+                'appendix and omit the header "appendix"'
+            ),
+            action="store_true",
+            default=False,
+        )
+        parser.add_argument(
+            "-A", dest="SourceAuthor", help=_("set author of source document")
+        )
+        parser.add_argument(
+            "-e",
+            dest="Editor",
+            help=_("set project editor"),
+            metavar="NAME",
+            default=None,
+        )
+        parser.add_argument(
+            "-i",
+            dest="Institution",
+            help=_("set institution (default TU Dresden)"),
+            metavar="NAME",
+            default=None,
+        )
+        parser.add_argument(
+            "-l",
+            dest="LectureTitle",
+            help=_("set title of project (first heading level 1 by " "default)"),
+            metavar="TITLE",
+            default=None,
+        )
+        parser.add_argument(
+            "-L",
+            dest="Language",
+            help=_("set document language (de by default)"),
+            default="de",
+        )
+        parser.add_argument(
+            "-p",
+            "--pnum-gap",
+            dest="PageNumberingGap",
+            help=_(
+                "specify gap between page numbering links in "
+                "navigation bar (default: 5)"
+            ),
+            metavar="NUM",
+            default=None,
+        )
+        parser.add_argument(
+            "-s",
+            dest="Source",
+            help=_("set information about source document"),
+            metavar="SRC",
+            default=None,
+        )
+        parser.add_argument(
+            "-S",
+            dest="SemesterOfEdit",
+            help=_("set semester of edit (will be guessed otherwise)"),
+            metavar="SEMYEAR",
+            default=None,
+        )
+        parser.add_argument(
+            "--toc-depth",
+            dest="TocDepth",
+            help=_("limit the heading depth for the table of contents"),
+            metavar="NUM",
+            default=None,
+        )
+        parser.add_argument(
+            "-w",
+            dest="WorkingGroup",
+            help=_("set working group"),
+            metavar="GROUP",
+            default=None,
+        )
 
-        if not args or args[0] not in ['show', 'update', 'init']:
-            parser.error(_('Error: no subcommand specified.'))
+        if not args or args[0] not in ["show", "update", "init"]:
+            parser.error(_("Error: no subcommand specified."))
             sys.exit(88)
         subcmd = args[0]
 
         options = parser.parse_args(args[1:])
-        if subcmd == 'init':
+        if subcmd == "init":
             # read configuration from cwd, if present
             inst = MAGSBS.config.LectureMetaData(MAGSBS.config.CONF_FILE_NAME)
             inst.write()
@@ -285,44 +352,60 @@ sub-directory configurations or initialization of a new project.""")
             except FileNotFoundError:
                 pass
 
-        if subcmd == 'show':
-            self.output_formatter.emit_result({_("Current settings"):
-                    {key.name: value for key, value in inst.items()}})
-        elif subcmd in ('update', 'init'):
+        if subcmd == "show":
+            self.output_formatter.emit_result(
+                {
+                    _("Current settings"): {
+                        key.name: value for key, value in inst.items()
+                    }
+                }
+            )
+        elif subcmd in ("update", "init"):
             for opt, value in options.__dict__.items():
                 if value is not None:
                     inst[MAGSBS.config.MetaInfo[opt]] = value
-            self.output_formatter.emit_result({_("New settings"):
-                    {key.name: value for key, value in inst.items()}})
+            self.output_formatter.emit_result(
+                {_("New settings"): {key.name: value for key, value in inst.items()}}
+            )
             inst.write()
         else:
             parser.print_help()
 
-
     def handle_conv(self, cmd, args):
         """Convert files."""
-        usage = _("Converts a file or directory containing a project.\n\n"
-                 "If a directory is supplied, additional steps such as "
-                 "generating a table of contents are performed as well.")
+        usage = _(
+            "Converts a file or directory containing a project.\n\n"
+            "If a directory is supplied, additional steps such as "
+            "generating a table of contents are performed as well."
+        )
         parser = HelpfulParser(cmd, self.output_formatter, usage)
-        parser.add_argument("-f", dest="format",
-                            help=_('select output format (html or epub, '
-                                'default html)'),
-                            metavar="FMT", default=None)
+        parser.add_argument(
+            "-f",
+            dest="format",
+            help=_("select output format (html or epub, " "default html)"),
+            metavar="FMT",
+            default=None,
+        )
         parser.add_argument("path", help=_("path to input file or directory"))
         args = parser.parse_args(args)
         if not os.path.exists(args.path):
-            self.output_formatter.emit_error(_('file or directory not found: %s'
-                        % args.path))
+            self.output_formatter.emit_error(
+                _("file or directory not found: %s" % args.path)
+            )
             sys.exit(127)
         with ErrorHandler(self.output_formatter):
             if os.path.isdir(args.path):
                 from MAGSBS.pandoc.formats import ConversionProfile, OutputFormat
+
                 m = MAGSBS.master.Master(
                     args.path,
                     ConversionProfile.Blind,
-                    (OutputFormat.Html if not args.format
-                     else OutputFormat.from_string(args.format)))
+                    (
+                        OutputFormat.Html
+                        if not args.format
+                        else OutputFormat.from_string(args.format)
+                    ),
+                )
                 m.run()
             else:
                 p = MAGSBS.pandoc.converter.Pandoc(root_path=os.getcwd())
@@ -330,24 +413,37 @@ sub-directory configurations or initialization of a new project.""")
                 # convcerting a single file.
                 p.convert_files((args.path,))
 
-
     def handle_imgdsc(self, cmd, args):
-        description = _("The working directory must be within a project; "
-                "the image path must be relative to the current "
-                "working directory.")
+        description = _(
+            "The working directory must be within a project; "
+            "the image path must be relative to the current "
+            "working directory."
+        )
         parser = HelpfulParser(cmd, self.output_formatter, description)
-        parser.add_argument("-d", "--description", dest="description",
-                help=_('image description string (- for reading stdin)'),
-                metavar="DESC", default='no description')
-        parser.add_argument("-o", "--outsource-descriptions", dest="outsource",
-                action="store_true", default=False,
-                help=_('outsource image descriptions regardless of their '
-                    'length'))
-        parser.add_argument("-t", "--title", dest="title",
-                default=None,
-                help=_('set title for outsourced images (mandatory if '
-                    'outsourced)'))
-        parser.add_argument('path', nargs="?", help="path to image file")
+        parser.add_argument(
+            "-d",
+            "--description",
+            dest="description",
+            help=_("image description string (- for reading stdin)"),
+            metavar="DESC",
+            default="no description",
+        )
+        parser.add_argument(
+            "-o",
+            "--outsource-descriptions",
+            dest="outsource",
+            action="store_true",
+            default=False,
+            help=_("outsource image descriptions regardless of their " "length"),
+        )
+        parser.add_argument(
+            "-t",
+            "--title",
+            dest="title",
+            default=None,
+            help=_("set title for outsourced images (mandatory if " "outsourced)"),
+        )
+        parser.add_argument("path", nargs="?", help="path to image file")
         options = parser.parse_args(args)
         if not options.path:
             parser.error(_("no path specified"))
@@ -364,48 +460,72 @@ sub-directory configurations or initialization of a new project.""")
         with ErrorHandler(self.output_formatter):
             # wrap all values in a "verbatim" dict, telling the formatter to not
             # reindent this value
-            self.output_formatter.emit_result({key: {'verbatim': value}
-                for key, value in img.get_output().items()})
+            self.output_formatter.emit_result(
+                {key: {"verbatim": value} for key, value in img.get_output().items()}
+            )
 
     def handle_iswithinlecture(self, cmd_name, args):
         """Tell the user whether a given path is part of a lecture or not."""
-        usage = _("Usage: {} iswithinlecture <path>\n\nTest whether the given "
-        "file or directory is part of a lecture.\n").format(cmd_name)
+        usage = _(
+            "Usage: {} iswithinlecture <path>\n\nTest whether the given "
+            "file or directory is part of a lecture.\n"
+        ).format(cmd_name)
         if not args:
             self.output_formatter.emit_usage(usage, _("path required"))
             sys.exit(127)
         elif len(args) > 1:
-            self.output_formatter.emit_usage(usage,
-                    _("only one path at a time allowed."))
+            self.output_formatter.emit_usage(
+                usage, _("only one path at a time allowed.")
+            )
             sys.exit(127)
         else:
-            if args[0] == '-h' or args[0] == '--help':
+            if args[0] == "-h" or args[0] == "--help":
                 self.output_formatter.emit_usage(usage)
                 sys.exit(0)
             else:
-                self.output_formatter.emit_result({'is within a lecture':
-                    MAGSBS.common.is_within_lecture(args[0])})
-
+                self.output_formatter.emit_result(
+                    {"is within a lecture": MAGSBS.common.is_within_lecture(args[0])}
+                )
 
     def handle_new(self, cmd, args):
-        description = _('Initialize a new lecture material or book directory.')
+        description = _("Initialize a new lecture material or book directory.")
         parser = HelpfulParser(cmd, self.output_formatter, description)
-        parser.add_argument("-a", dest="appendix_count", default="0", type=int,
-                metavar="COUNT",
-                help=_('number of appendix chapters (default 0)'))
-        parser.add_argument("-c", dest="chapter_count", default="2", type=int,
-                metavar="COUNT",
-                help=_('number of chapters (default 2)'))
-        parser.add_argument("-p", dest="preface", default=False,
-                action="store_true",
-                help=_('add a preface (default no)")'))
-        parser.add_argument("-n", dest="nochapter", default=False,
-                action="store_true",
-                help=_('if set, blattxx will be used instead of kxx'))
-        parser.add_argument("-l", dest="lang", default="de",
-                help=_('set language (default de)'))
-        parser.add_argument('directory', nargs="?",
-                help=_('new directory to create project in'))
+        parser.add_argument(
+            "-a",
+            dest="appendix_count",
+            default="0",
+            type=int,
+            metavar="COUNT",
+            help=_("number of appendix chapters (default 0)"),
+        )
+        parser.add_argument(
+            "-c",
+            dest="chapter_count",
+            default="2",
+            type=int,
+            metavar="COUNT",
+            help=_("number of chapters (default 2)"),
+        )
+        parser.add_argument(
+            "-p",
+            dest="preface",
+            default=False,
+            action="store_true",
+            help=_('add a preface (default no)")'),
+        )
+        parser.add_argument(
+            "-n",
+            dest="nochapter",
+            default=False,
+            action="store_true",
+            help=_("if set, blattxx will be used instead of kxx"),
+        )
+        parser.add_argument(
+            "-l", dest="lang", default="de", help=_("set language (default de)")
+        )
+        parser.add_argument(
+            "directory", nargs="?", help=_("new directory to create project in")
+        )
         options = parser.parse_args(args)
         if not options.directory:
             parser.print_help()
@@ -414,11 +534,11 @@ sub-directory configurations or initialization of a new project.""")
             a = int(options.appendix_count)
             c = int(options.chapter_count)
         except ValueError:
-            self.output_formatter.emit_error(_("The number of chapters and "
-                    "appendix chapters must be integers."))
+            self.output_formatter.emit_error(
+                _("The number of chapters and " "appendix chapters must be integers.")
+            )
             sys.exit(125)
-        builder = MAGSBS.filesystem.InitLecture(options.directory, c,
-                options.lang)
+        builder = MAGSBS.filesystem.InitLecture(options.directory, c, options.lang)
         builder.set_amount_appendix_chapters(a)
         if options.preface:
             builder.set_has_preface(True)
@@ -427,28 +547,48 @@ sub-directory configurations or initialization of a new project.""")
         builder.generate_structure()
 
     def handle_mk(self, cmd, args):
-        description = textwrap.dedent(_("""
+        description = textwrap.dedent(
+            _(
+                """
         Run "mistkerl", a quality assurance helper. It checks for common errors
         in accessible markdown documents and
-        outputs them on the command line."""))
+        outputs them on the command line."""
+            )
+        )
         parser = HelpfulParser(cmd, self.output_formatter, description)
-        parser.add_argument("-c", dest="critical_first", action="store_true",
-                help=_("Sort critical errors first"))
-        parser.add_argument("-s", dest="squeeze_output", action="store_true",
-                help=_("use less blank lines in output"))
-        parser.add_argument("-l", dest="live_view", action="store_true",
-                help=_("open a console-only live view, refreshing the list of "
-                    "errors every few seconds"))
-        parser.add_argument("input", nargs="?",
-                help=_("specify file or directory to be checked"))
+        parser.add_argument(
+            "-c",
+            dest="critical_first",
+            action="store_true",
+            help=_("Sort critical errors first"),
+        )
+        parser.add_argument(
+            "-s",
+            dest="squeeze_output",
+            action="store_true",
+            help=_("use less blank lines in output"),
+        )
+        parser.add_argument(
+            "-l",
+            dest="live_view",
+            action="store_true",
+            help=_(
+                "open a console-only live view, refreshing the list of "
+                "errors every few seconds"
+            ),
+        )
+        parser.add_argument(
+            "input", nargs="?", help=_("specify file or directory to be checked")
+        )
         options = parser.parse_args(args)
 
         if not options.input:
             self.output_formatter.emit_error(_("input file name required."))
             sys.exit(127)
         if not os.path.exists(options.input):
-            self.output_formatter.emit_error(_("Error: %s does not exist.") \
-                    % options.input)
+            self.output_formatter.emit_error(
+                _("Error: %s does not exist.") % options.input
+            )
             sys.exit(5)
 
         def format_errors():
@@ -463,7 +603,7 @@ sub-directory configurations or initialization of a new project.""")
                 # second arg is optional
                 pos = tuple(filter(bool, (mt.lineno, mt.pos_on_line)))
                 new = {pos: mt.message}
-                if not mt.path in transformed: # add sublist if not present
+                if not mt.path in transformed:  # add sublist if not present
                     transformed[mt.path] = []
                 transformed[mt.path].append(new)
             # sort errors by (lineno, pos_on_line); convert to readable
@@ -475,51 +615,76 @@ sub-directory configurations or initialization of a new project.""")
                     if not key:
                         messages[index] = message[key]
                     else:
-                        messages[index] = {', '.join(
-                                map(str, key)): message[key]}
+                        messages[index] = {", ".join(map(str, key)): message[key]}
             return transformed
 
         if options.live_view:
             import time
+
             try:
                 while True:
-                    mistakes = format_errors() # fetch before clearing screen
+                    mistakes = format_errors()  # fetch before clearing screen
                     self.output_formatter.clear()
                     self.output_formatter.emit_result(mistakes)
                     time.sleep(5)
             except KeyboardInterrupt:
-                pass # stop
+                pass  # stop
         else:
             self.output_formatter.emit_result(format_errors())
-
 
     def handle_addpnum(self, cmd, args):
         """Return a new page number (roman and arabic supported).
         The new page number is generated using it's predecessors. It both
         respects the numbering from the predecessor, as also the format (roman
         or arabic)."""
-        parser = HelpfulParser(cmd, self.output_formatter, description=_(
+        parser = HelpfulParser(
+            cmd,
+            self.output_formatter,
+            description=_(
                 "Generate a page number for a given context. A context "
                 "consists of a line and a file. The enumeration will "
                 "happen automatically (including distinction between roman and "
                 "arabic), as well as the detection of the language of the "
                 "lecture. This command will not insert the newly created "
                 "page number by default, but print it to stdout. This is meant "
-                "to be used by applications embedding Matuc's logic."))
-        parser.add_argument("-f", dest="read_from_file", action="store_true",
-                default=False, help=_("read from specified path instead of "
-                    "reading from standard input"))
-        parser.add_argument("-F", dest="rw_from_file", action="store_true",
-                default=False, help=_("read from specified path instead of "
-                    "reading from standard input and write result back to file; "
-                    "this could lead to race conditions on concurrent "
-                    "modifications"))
-        parser.add_argument('path', nargs=1,
-                help=_("Path to load configuration from. This can be either a "
+                "to be used by applications embedding Matuc's logic."
+            ),
+        )
+        parser.add_argument(
+            "-f",
+            dest="read_from_file",
+            action="store_true",
+            default=False,
+            help=_(
+                "read from specified path instead of " "reading from standard input"
+            ),
+        )
+        parser.add_argument(
+            "-F",
+            dest="rw_from_file",
+            action="store_true",
+            default=False,
+            help=_(
+                "read from specified path instead of "
+                "reading from standard input and write result back to file; "
+                "this could lead to race conditions on concurrent "
+                "modifications"
+            ),
+        )
+        parser.add_argument(
+            "path",
+            nargs=1,
+            help=_(
+                "Path to load configuration from. This can be either a "
                 "file or a directory. If -f is given, the path is used as "
-                "input file (by default, input is read from stdin)"))
-        parser.add_argument('line_number', nargs=1,
-                help=_("Line number for which to generate the page number"))
+                "input file (by default, input is read from stdin)"
+            ),
+        )
+        parser.add_argument(
+            "line_number",
+            nargs=1,
+            help=_("Line number for which to generate the page number"),
+        )
 
         options = parser.parse_args(args)
         path = options.path[0]
@@ -535,45 +700,69 @@ sub-directory configurations or initialization of a new project.""")
         # file if -F given
         if options.read_from_file or options.rw_from_file:
             if not os.path.isfile(path):
-                self.output_formatter.emit_error(_("Given path is not a file, "
-                        "but reading from it with -f has been requested."))
+                self.output_formatter.emit_error(
+                    _(
+                        "Given path is not a file, "
+                        "but reading from it with -f has been requested."
+                    )
+                )
                 return 99
             text = pagenumbering.add_page_number(path, line_number).format()
 
-            if options.read_from_file: # print to stdout
-                self.output_formatter.emit_result({'pagenumber': text})
-            else: # read and write into given path
-                with open(path, encoding='utf-8') as f:
-                    lines = f.read().split('\n')
+            if options.read_from_file:  # print to stdout
+                self.output_formatter.emit_result({"pagenumber": text})
+            else:  # read and write into given path
+                with open(path, encoding="utf-8") as f:
+                    lines = f.read().split("\n")
                 lines = insert_line(lines, line_number, text)
-                with open(path, 'w', encoding='utf-8') as f:
-                    f.write('\n'.join(lines))
+                with open(path, "w", encoding="utf-8") as f:
+                    f.write("\n".join(lines))
         else:
             data = sys.stdin.read()
-            self.output_formatter.emit_result({'pagenumber':
-                pagenumbering.add_page_number_from_str(data, line_number,
-                    path=path).format()})
+            self.output_formatter.emit_result(
+                {
+                    "pagenumber": pagenumbering.add_page_number_from_str(
+                        data, line_number, path=path
+                    ).format()
+                }
+            )
         return 0
-
 
     def handle_fixpnums(self, cmd, args):
         """Please see usage info."""
-        parser = HelpfulParser(cmd, self.output_formatter, description= \
-            _("Check the page numbers of a document and warn / fix the page "
+        parser = HelpfulParser(
+            cmd,
+            self.output_formatter,
+            description=_(
+                "Check the page numbers of a document and warn / fix the page "
                 "numbering, if the numbers do not strictly increase by one.\n"
-                "This command reads from stdin by default, see -f."))
-        parser.add_argument("-f", dest="file", metavar="FILE",
-                default=None, help=_("read from specified path instead of "
-                    "reading from standard input"))
-        parser.add_argument("-i", dest="in_place", action="store_true",
-            help=_("if -f is given, replace the page numbering in the "
-                "file in-place"))
+                "This command reads from stdin by default, see -f."
+            ),
+        )
+        parser.add_argument(
+            "-f",
+            dest="file",
+            metavar="FILE",
+            default=None,
+            help=_(
+                "read from specified path instead of " "reading from standard input"
+            ),
+        )
+        parser.add_argument(
+            "-i",
+            dest="in_place",
+            action="store_true",
+            help=_(
+                "if -f is given, replace the page numbering in the " "file in-place"
+            ),
+        )
 
         options = parser.parse_args(args)
 
         if options.in_place and not options.file:
-            self.output_formatter.emit_error(_("In-place modifications "
-                    "requested, but no file given."))
+            self.output_formatter.emit_error(
+                _("In-place modifications " "requested, but no file given.")
+            )
             sys.exit(73)
 
         if options.file and not os.path.exists(options.file):
@@ -591,28 +780,27 @@ sub-directory configurations or initialization of a new project.""")
             self.output_formatter.emit_result([])
             sys.exit(0)
 
-        corrected = [] # correct page numbers
+        corrected = []  # correct page numbers
         for pnum, expected_num in errorneous:
             pnum.number = expected_num
             corrected.append({str(pnum.line_no): pnum.format()})
 
         if options.in_place:
-            with open(options.file, 'r', encoding='utf-8') as f:
-                lines = f.read().split('\n')
+            with open(options.file, "r", encoding="utf-8") as f:
+                lines = f.read().split("\n")
                 # destructure list of dicts into list of tuples
                 for lnum, string in (x for d in corrected for x in d.items()):
-                    lines[int(lnum) - 1] = string # inefficient, but easier to
-            with open(options.file, 'w', encoding='utf-8') as f:
-                f.write('\n'.join(lines))
+                    lines[int(lnum) - 1] = string  # inefficient, but easier to
+            with open(options.file, "w", encoding="utf-8") as f:
+                f.write("\n".join(lines))
         else:
             self.output_formatter.emit_result(corrected)
             sys.exit(0)
 
-
-    #pylint: disable=unused-argument
+    # pylint: disable=unused-argument
     def handle_version(self, dont, care):
-        self.output_formatter.emit_result({'version':
-                str(MAGSBS.config.VERSION)})
+        self.output_formatter.emit_result({"version": str(MAGSBS.config.VERSION)})
+
 
 def insert_line(lines, line_number, line):
     """This function allows the insertion of a line into a list of lines. It
@@ -623,19 +811,19 @@ def insert_line(lines, line_number, line):
     if line_number < 1:
         raise ValueError("line numbers count from one")
     # careful: line_number counts from 1
-    if line_number >= len(lines): # end of document
-        if lines and lines[-1].strip(): # no newline at end
-            lines.append('')
+    if line_number >= len(lines):  # end of document
+        if lines and lines[-1].strip():  # no newline at end
+            lines.append("")
         lines.append(line)
     elif line_number == 1:
         lines.insert(0, line)
         if len(lines) > 1 and lines[1].strip():
-            lines.insert(1, '')
+            lines.insert(1, "")
     else:
-        if not lines[line_number-2] == '':
-            lines = lines[:line_number-1] + [''] + lines[line_number-1:]
+        if not lines[line_number - 2] == "":
+            lines = lines[: line_number - 1] + [""] + lines[line_number - 1 :]
         lines = lines[:line_number] + [line] + lines[line_number:]
         print(lines[line_number])
-        if lines[line_number+1].strip(): # no newline at end
-            lines = lines[:line_number+1] + [''] + lines[line_number+1:]
+        if lines[line_number + 1].strip():  # no newline at end
+            lines = lines[: line_number + 1] + [""] + lines[line_number + 1 :]
     return lines

--- a/MAGSBS/matuc_js.py
+++ b/MAGSBS/matuc_js.py
@@ -9,9 +9,10 @@ matuc and alters the OutputFormatter to print JSON."""
 import json
 import os
 import sys
+
 try:
     import matuc_impl
-except (SystemError, ModuleNotFoundError): # usually happens when executing from source
+except (SystemError, ModuleNotFoundError):  # usually happens when executing from source
     try:
         from matuc_impl import matuc_impl
     except ModuleNotFoundError:
@@ -19,32 +20,34 @@ except (SystemError, ModuleNotFoundError): # usually happens when executing from
 
 # enable debugging for matuc_js, since it is an API internface and it is
 # useful to report errors when they occur
-os.environ['DEBUG'] = str(1)
+os.environ["DEBUG"] = str(1)
+
 
 class JsonFormatter(matuc_impl.OutputFormatter):
     """Out formatter which displays all messages and objects as JSON objects."""
+
     def __emit_json(self, object):
-        sys.stdout.write(json.dumps(object, indent=2, sort_keys=True) + '\n')
+        sys.stdout.write(json.dumps(object, indent=2, sort_keys=True) + "\n")
 
     def emit_result(self, result):
         warnings = self.get_warnings()
         output = {}
         if warnings:
-            output['warnings'] = warnings
-        output['result'] = result
+            output["warnings"] = warnings
+        output["result"] = result
         self.__emit_json(output)
 
     def emit_error(self, error):
         warnings = self.get_warnings()
-        output = {'error': error}
+        output = {"error": error}
         if warnings:
-            output['warnings'] = warnings
+            output["warnings"] = warnings
         self.__emit_json(output)
 
     def emit_usage(self, usage, error=None):
-        output = {'usage': usage}
+        output = {"usage": usage}
         if error:
-            output['error'] = error.rstrip()
+            output["error"] = error.rstrip()
         self.__emit_json(output)
 
     def clear(self):
@@ -57,5 +60,5 @@ def main():
     main_inst.run(sys.argv)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/MAGSBS/mparser/__init__.py
+++ b/MAGSBS/mparser/__init__.py
@@ -37,34 +37,37 @@ def joined_line_iterator(lines):
     lines_to_insert = 0
     insert_blank_lines_now = False
     while has_next:
-        try: # try to fetch next line
+        try:  # try to fetch next line
             line = next(myiter)
         except StopIteration:
             has_next = False
             break
         # join as long as a \ is at the end
-        while line.rstrip().endswith('\\'): # rstrip strips \n
-            line = line.rstrip()[:-1] + ' ' # strip \
+        while line.rstrip().endswith("\\"):  # rstrip strips \n
+            line = line.rstrip()[:-1] + " "  # strip \
             try:
                 nextline = next(myiter)
             except StopIteration:
                 break
             lines_to_insert += 1
-            if nextline.strip() == '': # empty lines don't get appended at the end of previous line
+            if (
+                nextline.strip() == ""
+            ):  # empty lines don't get appended at the end of previous line
                 insert_blank_lines_now = True
-                line = '' # reset it to '' so that following code inserts blank lines
+                line = ""  # reset it to '' so that following code inserts blank lines
                 break
             line += nextline
         # return line
         yield line
         if insert_blank_lines_now:
             insert_blank_lines_now = False
-            line = '' # trigger line insertion for missing joined lines
-        if lines_to_insert > 0 and line.strip() == '':
+            line = ""  # trigger line insertion for missing joined lines
+        if lines_to_insert > 0 and line.strip() == "":
             # insert as many lines as were joined to retain line numbering
             for _ in range(0, lines_to_insert):
-                yield ''
+                yield ""
             lines_to_insert = 0
+
 
 def file2paragraphs(lines, join_lines=False):
     """
@@ -76,23 +79,23 @@ parameter must  be iterable, so can be a file object or a list of lines. It can
 be a string, in this case it's split on \\n.
 If join_lines is set, lines ending on \\ will we joined with the next one.
 """
-    #pylint: disable=bad-reversed-sequence
+    # pylint: disable=bad-reversed-sequence
     if isinstance(lines, str):
-        lines = lines.split('\n')
+        lines = lines.split("\n")
     paragraphs = collections.OrderedDict()
     paragraphs[1] = []
 
-    iterator_wrappper = (joined_line_iterator if join_lines else iter)
+    iterator_wrappper = joined_line_iterator if join_lines else iter
     for lnum, line in enumerate(iterator_wrappper(lines)):
         current_paragraph = next(reversed(paragraphs))
-        line = line.rstrip() # remove \n, if it exists
-        if not line: # empty line
+        line = line.rstrip()  # remove \n, if it exists
+        if not line:  # empty line
             # if previous paragraph is empty, this line as well, theere are
             # multiple blank lines; update line number
             if not paragraphs[current_paragraph]:
                 del paragraphs[current_paragraph]
             # +1, because count starts from 1 and paragraph starts on next line
-            paragraphs[lnum+2] = []
+            paragraphs[lnum + 2] = []
         else:
             paragraphs[current_paragraph].append(line)
     # strip empty paragraphs at the end (\n at EOF)
@@ -102,7 +105,6 @@ If join_lines is set, lines ending on \\ will we joined with the next one.
     return paragraphs
 
 
-
 def extract_page_numbers(path, ignore_after_lnum=-1):
     """Extract page numbers from given file.
     Internally, extract_page_numbers_from_par is called.
@@ -110,13 +112,16 @@ def extract_page_numbers(path, ignore_after_lnum=-1):
     It is set to -1 by default.
     Returned is a list of page numbers. See extract_page_numbers_from_string for
     the actual format."""
-    with open(path, 'r', encoding='utf-8') as f:
+    with open(path, "r", encoding="utf-8") as f:
         paragraphs = file2paragraphs(f.read())
-        return extract_page_numbers_from_par(paragraphs,
-                ignore_after_lnum=ignore_after_lnum)
+        return extract_page_numbers_from_par(
+            paragraphs, ignore_after_lnum=ignore_after_lnum
+        )
 
-def extract_page_numbers_from_par(paragraphs, ignore_after_lnum=-1,
-        regex=config.PAGENUMBERING_PATTERN):
+
+def extract_page_numbers_from_par(
+    paragraphs, ignore_after_lnum=-1, regex=config.PAGENUMBERING_PATTERN
+):
     """Extract all page numbers from a document.
     Arguments:
     1.  paragraph list, a list of all paragraphs in the document, see `file2paragraphs` for more details.
@@ -133,10 +138,13 @@ def extract_page_numbers_from_par(paragraphs, ignore_after_lnum=-1,
         ignore_after_lnum = max(paragraphs.keys()) + 1
     # filter for paragraphs with exactly one line and the line starting with||
     # and before ignore_after_lnum
-    paragraphs = ((l,p) for l,p in paragraphs.items() \
-            if len(p) == 1 and p[0].startswith('||') and l <= ignore_after_lnum)
+    paragraphs = (
+        (l, p)
+        for l, p in paragraphs.items()
+        if len(p) == 1 and p[0].startswith("||") and l <= ignore_after_lnum
+    )
 
-    paragraphs=list(paragraphs)
+    paragraphs = list(paragraphs)
     for start_line, par in paragraphs:
         result = regex.search(par[0])
         if not result:
@@ -146,22 +154,24 @@ def extract_page_numbers_from_par(paragraphs, ignore_after_lnum=-1,
         is_arabic = True
         try:
             number = int(number)
-        except ValueError: # try roman number
+        except ValueError:  # try roman number
             try:
                 number = roman.from_roman(number)
                 is_arabic = False
             except roman.InvalidRomanNumeralError:
-                raise errors.FormattingError("cannot recognize page number",
-                        number, line=start_line)
-
+                raise errors.FormattingError(
+                    "cannot recognize page number", number, line=start_line
+                )
 
         pnum = datastructures.PageNumber(id, number, is_arabic=is_arabic)
         pnum.line_no = start_line
         numbers.append(pnum)
     return numbers
 
+
 ################################################################################
 #   formula parser
+
 
 def compute_position(text_before, accumulated_stringlength=1):
     """compute_position(text_before, accumulated_stringlength)
@@ -175,18 +185,18 @@ def compute_position(text_before, accumulated_stringlength=1):
     assert compute_position('') == 1
     assert compute_position('a\n', 1) == 1
     assert compute_position('ab', 1) == 3"""
-    pos = text_before.rfind('\n')
-    if pos == -1: # no line break in text before formula, count characters and return as position
+    pos = text_before.rfind("\n")
+    if (
+        pos == -1
+    ):  # no line break in text before formula, count characters and return as position
         return len(text_before) + accumulated_stringlength
     elif pos == len(text_before):
-        return 1 # formula was first character on new line
+        return 1  # formula was first character on new line
     else:
         return len(text_before[pos + 1 :]) + 1
 
 
-
-def parse_environments(document, indicator='$$', stripped_document=None,
-        start_line=1):
+def parse_environments(document, indicator="$$", stripped_document=None, start_line=1):
     """parse_environments(document, indicator='$$'', stripped_document=None,
     start_line=1)
     This function will parse environments starting with a configurable indicator
@@ -207,9 +217,9 @@ def parse_environments(document, indicator='$$', stripped_document=None,
     formulas = {}
     formula_started = False
     line_number = start_line
-    last_plain_text = ''
+    last_plain_text = ""
     pos_in_line = 1
-    document = document.replace(r'\$', '  ') # remove escaped dollars
+    document = document.replace(r"\$", "  ")  # remove escaped dollars
     for token in document.split(indicator):
         if formula_started:
             pos = compute_position(last_plain_text, pos_in_line)
@@ -217,13 +227,15 @@ def parse_environments(document, indicator='$$', stripped_document=None,
             # the new position depends on the length of formula and line breaks
             pos_in_line = compute_position(token, pos) + 2 * len(indicator)
             if stripped_document is not None:
-                stripped_document.append(' ' * (len(token) + 2 * len(indicator)))
+                stripped_document.append(" " * (len(token) + 2 * len(indicator)))
         else:
-            last_plain_text = token # save non-formula text for later position retrieval
+            last_plain_text = (
+                token  # save non-formula text for later position retrieval
+            )
             if stripped_document is not None:
                 stripped_document.append(token)
-        formula_started = not formula_started # toggles every time
-        line_number += token.count('\n')
+        formula_started = not formula_started  # toggles every time
+        line_number += token.count("\n")
     return formulas
 
 
@@ -238,20 +250,20 @@ def parse_single_dollar_formulas(document, start_line=1):
 
     will yield {(1, 13): ...}."""
     formulas = {}
-    for lnum, line in enumerate(document.split('\n'), start_line):
-        tokens = line.split('$')
-        if len(tokens) < 3: # one or less dollars, ignore
+    for lnum, line in enumerate(document.split("\n"), start_line):
+        tokens = line.split("$")
+        if len(tokens) < 3:  # one or less dollars, ignore
             continue
         pos = 0
-        is_formula = True # negated at beginning of iteration; counts whether
-                # current token is a formula or not
-        last_added = None # last key added to list of formulas
+        is_formula = True  # negated at beginning of iteration; counts whether
+        # current token is a formula or not
+        last_added = None  # last key added to list of formulas
         for token in tokens:
-            is_formula = not is_formula # flip flop, flip flop....
+            is_formula = not is_formula  # flip flop, flip flop....
             if is_formula:
-                last_added = (lnum, pos+1) # save last added key
+                last_added = (lnum, pos + 1)  # save last added key
                 formulas[last_added] = token
-                pos += 2 # count the two dollars of the math environment
+                pos += 2  # count the two dollars of the math environment
             pos += len(token)
         # if not is_formula, an environment was untermined or a dollar not escaped,
         # discard last formula, possibly whole line is broken
@@ -259,18 +271,28 @@ def parse_single_dollar_formulas(document, start_line=1):
             del formulas[last_added]
     return formulas
 
+
 def parse_formulas(paragraphs):
     """Parse all formulas from a document. Note: this function is rather costly,
     since it involves a lot of string operations.
     Returned is an OrderedDict with formulas in the correct order."""
     formulas = {}
     for start_lnum, paragraph in paragraphs.items():
-        paragraph = '\n'.join(paragraph)
-        parsed_paragraph = [] # paragraph with $$-environments removed
-        formulas.update(parse_environments(paragraph, indicator='$$',
-                stripped_document=parsed_paragraph, start_line=start_lnum))
-        formulas.update(parse_single_dollar_formulas(''.join(parsed_paragraph),
-            start_line=start_lnum))
+        paragraph = "\n".join(paragraph)
+        parsed_paragraph = []  # paragraph with $$-environments removed
+        formulas.update(
+            parse_environments(
+                paragraph,
+                indicator="$$",
+                stripped_document=parsed_paragraph,
+                start_line=start_lnum,
+            )
+        )
+        formulas.update(
+            parse_single_dollar_formulas(
+                "".join(parsed_paragraph), start_line=start_lnum
+            )
+        )
     ordered = collections.OrderedDict()
     for position in sorted(formulas):
         ordered[position] = formulas[position]

--- a/MAGSBS/mparser/headings.py
+++ b/MAGSBS/mparser/headings.py
@@ -7,9 +7,7 @@ import re
 
 from .. import datastructures
 
-_hashed_heading = re.compile(r'^#{1,6}(?!\.)\s*.*?\w+')
-
-
+_hashed_heading = re.compile(r"^#{1,6}(?!\.)\s*.*?\w+")
 
 
 def parse_hashed_headings(text):
@@ -18,10 +16,10 @@ def parse_hashed_headings(text):
     >>>> parse_hashed_headings("### foo bar")
     (3, 'foo bar')"""
     level = 0
-    while text.startswith('#'):
+    while text.startswith("#"):
         level += 1
         text = text[1:]
-    while text.endswith('#'):
+    while text.endswith("#"):
         text = text[:-1]
     text = text.lstrip().rstrip()
     return (text, level)
@@ -32,21 +30,20 @@ def is_hashed_heading(line):
     return bool(_hashed_heading.search(line))
 
 
-
 def __extract_hashed(start_line, paragraph):
     prevline = []
     for lnum, line in enumerate(paragraph):
         if prevline:
-            prevline[1] += '\n' + line
-            if line.rstrip().endswith('\\'):
+            prevline[1] += "\n" + line
+            if line.rstrip().endswith("\\"):
                 continue
-            else: # continuation ended
+            else:  # continuation ended
                 h = datastructures.Heading(*parse_hashed_headings(prevline[1]))
                 h.set_line_number(start_line + prevline[0])
                 prevline = None
                 yield h
         elif is_hashed_heading(line):
-            if line.endswith('\\'):
+            if line.endswith("\\"):
                 prevline = [lnum, line[:-1].rstrip()]
             else:
                 h = datastructures.Heading(*parse_hashed_headings(line))
@@ -55,8 +52,8 @@ def __extract_hashed(start_line, paragraph):
         else:
             break
 
-def extract_headings_from_par(paragraphs, max_headings=-1,
-        remove_duplicates=True):
+
+def extract_headings_from_par(paragraphs, max_headings=-1, remove_duplicates=True):
     """extract_headings_from_par(list_of_paragraphs, max_headings=-1)
     Return list of heading objects; if max_headings is set to a value > -1, only
     this number of headings will be parsed.
@@ -65,11 +62,15 @@ def extract_headings_from_par(paragraphs, max_headings=-1,
     won't be set. Please use extract_headings instead.
     """
     headings = []
+
     def add_heading(start_line, text, level):
         nonlocal headings
-        if remove_duplicates and headings and \
-                headings[-1].get_text().strip() == text.strip():
-            return # do not add duplicates
+        if (
+            remove_duplicates
+            and headings
+            and headings[-1].get_text().strip() == text.strip()
+        ):
+            return  # do not add duplicates
         h = datastructures.Heading(text, level)
         h.set_line_number(start_line)
         headings.append(h)
@@ -81,29 +82,37 @@ def extract_headings_from_par(paragraphs, max_headings=-1,
             continue
         if is_hashed_heading(paragraph[0]):
             for heading in __extract_hashed(start_line, paragraph):
-                if remove_duplicates and headings and headings[-1].get_text()\
-                        .strip() == heading.get_text().strip():
-                    continue # skip doubled headings
+                if (
+                    remove_duplicates
+                    and headings
+                    and headings[-1].get_text().strip() == heading.get_text().strip()
+                ):
+                    continue  # skip doubled headings
                 headings.append(heading)
-            continue # skip this paragraph, was parsed
+            continue  # skip this paragraph, was parsed
         # find --- or ===, for this, read the "first line", including line
         # continuation instructions
-        potential_underline_at = 0 # second line
-        text = ''
-        if paragraph[0].endswith('\\'):
-            while potential_underline_at < len(paragraph) and \
-                    paragraph[potential_underline_at].endswith('\\'):
-                text += paragraph[potential_underline_at].rstrip('\\') + '\n'
+        potential_underline_at = 0  # second line
+        text = ""
+        if paragraph[0].endswith("\\"):
+            while potential_underline_at < len(paragraph) and paragraph[
+                potential_underline_at
+            ].endswith("\\"):
+                text += paragraph[potential_underline_at].rstrip("\\") + "\n"
                 potential_underline_at += 1
         if potential_underline_at < len(paragraph):
-            text += paragraph[potential_underline_at] # get last line without backslash
-        potential_underline_at += 1 # ended on last line of text, need to be at underline
+            text += paragraph[potential_underline_at]  # get last line without backslash
+        potential_underline_at += (
+            1  # ended on last line of text, need to be at underline
+        )
         if potential_underline_at >= len(paragraph):
-            continue # no underline
-        if paragraph[potential_underline_at].startswith('==='):
+            continue  # no underline
+        if paragraph[potential_underline_at].startswith("==="):
             add_heading(start_line, text, 1)
-        elif paragraph[potential_underline_at].startswith('---') and \
-                not ' ' in paragraph[potential_underline_at]:
+        elif (
+            paragraph[potential_underline_at].startswith("---")
+            and not " " in paragraph[potential_underline_at]
+        ):
             add_heading(start_line, text, 2)
     return headings
 
@@ -117,10 +126,9 @@ def extract_headings(path, paragraphs, remove_duplicates=True):
     only the first kept."""
     headings = []
     chapter_number = datastructures.extract_chapter_number(path)
-    for heading in extract_headings_from_par(paragraphs,
-            remove_duplicates=remove_duplicates):
+    for heading in extract_headings_from_par(
+        paragraphs, remove_duplicates=remove_duplicates
+    ):
         heading.set_chapter_number(chapter_number)
         headings.append(heading)
     return headings
-
-

--- a/MAGSBS/mparser/links.py
+++ b/MAGSBS/mparser/links.py
@@ -51,7 +51,7 @@ def find_links_in_markdown(text, init_lineno=1, init_position=1):
         # cases when [ is within formula)
         if text[index] == "[" and not escape_next and not is_in_formula:
             beginning = index - max(0, index - 2)
-            chars, reference = extract_link(text[index - beginning:])
+            chars, reference = extract_link(text[index - beginning :])
             # chars recalculation - beginning should not be counted twice
             chars = chars - beginning
             # result processing, but not when it is a to-do list
@@ -62,12 +62,14 @@ def find_links_in_markdown(text, init_lineno=1, init_position=1):
                 # there should be some inner references within line text
                 if reference.id:
                     for inner_reference in find_links_in_markdown(
-                            reference.id, lineno, position):
+                        reference.id, lineno, position
+                    ):
                         output.append(inner_reference)
                 # there should be some inner references in link itself
                 if reference.link:
                     for inner_reference in find_links_in_markdown(
-                            reference.link, lineno, position):
+                        reference.link, lineno, position
+                    ):
                         output.append(inner_reference)
                 # recalculate the index char, number of lines and position
                 for _ in range(index, index + chars):
@@ -77,8 +79,11 @@ def find_links_in_markdown(text, init_lineno=1, init_position=1):
                         lineno += 1
                         position = 1
 
-        escape_next = True if index < len(text) and \
-            text[index] == "\\" and not escape_next else False
+        escape_next = (
+            True
+            if index < len(text) and text[index] == "\\" and not escape_next
+            else False
+        )
         index += 1
         position += 1
     return output
@@ -89,9 +94,9 @@ def extract_link(text):
     Parameter text should contain opening square bracket.
     Then it is resolved and new instance of Reference class is returned. """
     if "[" not in text:
-        raise ValueError("Text for extracting link must contain \"[\".")
+        raise ValueError('Text for extracting link must contain "[".')
     index = text.find("[")
-    image_char, is_footnote = detect_image_footnote(text[:index + 2], index)
+    image_char, is_footnote = detect_image_footnote(text[: index + 2], index)
 
     # [ ... whatever ... ] part
     first_part = get_text_inside_brackets(text[index:])
@@ -100,33 +105,61 @@ def extract_link(text):
     # solve labeled
     if index < len(text) - 1 and text[index] == "[" and text[index + 1] != "]":
         second_part = get_text_inside_brackets(text[index:])
-        return index + second_part[0], Reference(
-            Reference.Type.IMPLICIT, image_char, identifier=second_part[1],
-            is_footnote=is_footnote)
+        return (
+            index + second_part[0],
+            Reference(
+                Reference.Type.IMPLICIT,
+                image_char,
+                identifier=second_part[1],
+                is_footnote=is_footnote,
+            ),
+        )
     elif index < len(text) and text[index] == "(":  # inline links
         second_part = get_text_inside_brackets(text[index:])
         second_part_str = second_part[1]
         if second_part_str.find(r" ") != -1:
-            second_part_str = second_part_str[:second_part_str.find(r" ")]
-        return index + second_part[0], Reference(
-            Reference.Type.INLINE, image_char, identifier=first_part[1],
-            link=second_part_str)
+            second_part_str = second_part_str[: second_part_str.find(r" ")]
+        return (
+            index + second_part[0],
+            Reference(
+                Reference.Type.INLINE,
+                image_char,
+                identifier=first_part[1],
+                link=second_part_str,
+            ),
+        )
     elif index < len(text) and text[index] == ":":  # explicit reference links
         if is_footnote:  # explicit reference to footnote
             end_index = text[index:].find("\n\n")
             # no two newlines there till end of string
             end_index = len(text) if end_index < 0 else end_index + index
 
-            return end_index, Reference(
-                Reference.Type.EXPLICIT, image_char, identifier=first_part[1],
-                link=text[index + 2:end_index], is_footnote=True)
+            return (
+                end_index,
+                Reference(
+                    Reference.Type.EXPLICIT,
+                    image_char,
+                    identifier=first_part[1],
+                    link=text[index + 2 : end_index],
+                    is_footnote=True,
+                ),
+            )
         # explicit reference link, is ended by first whitespace after ": "
-        link = text[index + 1:].split(None, 1)[0]
-        return index + len(link), Reference(Reference.Type.EXPLICIT,
-                                            image_char, first_part[1], link)
+        link = text[index + 1 :].split(None, 1)[0]
+        return (
+            index + len(link),
+            Reference(Reference.Type.EXPLICIT, image_char, first_part[1], link),
+        )
     # nothing from previous = implicit reference link
-    return index, Reference(Reference.Type.IMPLICIT, image_char,
-                            identifier=first_part[1], is_footnote=is_footnote)
+    return (
+        index,
+        Reference(
+            Reference.Type.IMPLICIT,
+            image_char,
+            identifier=first_part[1],
+            is_footnote=is_footnote,
+        ),
+    )
 
 
 def detect_image_footnote(text, index):
@@ -143,8 +176,7 @@ def detect_image_footnote(text, index):
     else:
         is_image = False
 
-    is_footnote = True if len(text) > index + 1 and text[index + 1] == "^" \
-        else False
+    is_footnote = True if len(text) > index + 1 and text[index + 1] == "^" else False
 
     return is_image, is_footnote
 
@@ -173,8 +205,7 @@ def get_text_inside_brackets(text):
             count_brackets += 1
         if text[index] == closing_bracket_char and not escape_next:
             count_brackets -= 1
-        escape_next = True if text[index] == "\\" and not escape_next \
-            else False
+        escape_next = True if text[index] == "\\" and not escape_next else False
 
         output += text[index]
         index += 1
@@ -186,8 +217,11 @@ def is_todo_or_empty(reference):
     """This methods returns True if the implicit reference represents
     todo list in markdown format (i.e. in format [ ] or [x]) or identifier
     is empty, False otherwise."""
-    return reference.type == Reference.Type.IMPLICIT and \
-        not reference.link and reference.id.lower() in (" ", "x", "")
+    return (
+        reference.type == Reference.Type.IMPLICIT
+        and not reference.link
+        and reference.id.lower() in (" ", "x", "")
+    )
 
 
 def get_html_elements_identifiers(document):

--- a/MAGSBS/mparser/remove_codeblocks.py
+++ b/MAGSBS/mparser/remove_codeblocks.py
@@ -9,11 +9,12 @@ import re
 def all_lines_indented(lines):
     """An indented code block must indent all lines (except for empty ones) with
     four spaces or a tab."""
-    return all(not l or l.startswith('    ') or l.startswith('\t') for l in
-            lines)
+    return all(not l or l.startswith("    ") or l.startswith("\t") for l in lines)
+
 
 def is_even(num):
     return (num % 2) == 0
+
 
 def rm_codeblocks(paragraphs):
     """This functions takes an ordered dict with line numbers mapping to a list
@@ -27,18 +28,20 @@ def rm_codeblocks(paragraphs):
     modified_paragraphs = paragraphs.copy()
 
     for start_line, par in paragraphs.items():
-        changed = handle_fenced_blocks(modified_paragraphs, start_line, '~~~')
+        changed = handle_fenced_blocks(modified_paragraphs, start_line, "~~~")
         if not changed:
-            changed = handle_fenced_blocks(modified_paragraphs, start_line, '```')
-        par = modified_paragraphs[start_line] # update, just to be sure
+            changed = handle_fenced_blocks(modified_paragraphs, start_line, "```")
+        par = modified_paragraphs[start_line]  # update, just to be sure
         if not changed:
             # if all lines start with indentation
-            if all_lines_indented(par) and not is_indented_itemize(modified_paragraphs, start_line):
-                modified_paragraphs[start_line] = [''] * (len(par) + 1)
-            else: # try to replace `inline`-environments
+            if all_lines_indented(par) and not is_indented_itemize(
+                modified_paragraphs, start_line
+            ):
+                modified_paragraphs[start_line] = [""] * (len(par) + 1)
+            else:  # try to replace `inline`-environments
                 for index, line in enumerate(par):
-                    if '`' in line and is_even(line.count('`')):
-                        par[index] = re.sub('`.*?`', '  ', line)
+                    if "`" in line and is_even(line.count("`")):
+                        par[index] = re.sub("`.*?`", "  ", line)
                 modified_paragraphs[start_line] = par
     return modified_paragraphs
 
@@ -52,13 +55,13 @@ def is_indented_itemize(paragraphs, current_startline):
     for lineno in reversed(keys[:idx]):
         par = paragraphs[lineno]
         # any itemize environment in this paragraph?
-        if any(len(l) > 1 and l.lstrip()[:2] in ['- ', '+ ', '* ']
-                        for l in par):
-            return True # I'm aware that indented code blocks with an example markdown list won't work
+        if any(len(l) > 1 and l.lstrip()[:2] in ["- ", "+ ", "* "] for l in par):
+            return True  # I'm aware that indented code blocks with an example markdown list won't work
         elif all_lines_indented(par):
-            continue # not clear whether it's a list
-        else: # no itemize, no indentation — not an indented itemize
+            continue  # not clear whether it's a list
+        else:  # no itemize, no indentation — not an indented itemize
             return False
+
 
 def skip_until(iterable, requested_key):
     """Return an iterator which fast-forwards beyond the specified key."""
@@ -75,8 +78,9 @@ def handle_fenced_blocks(paragraphs, start_line, indicator):
     through empty lines. If a code block spans multiple lines, it'll peek
     forward to find the end. This function will itself update the paragraphs
     from the paragraphs input parameter, so works directly on the reference."""
-    indicator_count = sum(1 for line in paragraphs[start_line]
-            if line.lstrip().startswith(indicator))
+    indicator_count = sum(
+        1 for line in paragraphs[start_line] if line.lstrip().startswith(indicator)
+    )
     if indicator_count == 0:
         return False
 
@@ -85,25 +89,23 @@ def handle_fenced_blocks(paragraphs, start_line, indicator):
     keys = chain([start_line], skip_until(paragraphs.keys(), start_line))
     for number, key in enumerate(keys):
         if number > 6:
-            break # dangling code block delimiter and already 7 paragraphs
-                  # parsed, give up
-        paragraph = paragraphs[key][:] # copy
+            break  # dangling code block delimiter and already 7 paragraphs
+            # parsed, give up
+        paragraph = paragraphs[key][:]  # copy
         for index, line in enumerate(paragraphs[key]):
             if line.lstrip().startswith(indicator):
                 within_code_block = not within_code_block
-                paragraph[index] = ''
+                paragraph[index] = ""
             else:
                 if within_code_block:
-                    paragraph[index] = ''
+                    paragraph[index] = ""
         if key == start_line:
-            paragraphs[key] = paragraph # replace content
+            paragraphs[key] = paragraph  # replace content
             if (indicator_count % 2) == 0:
                 break
         elif not is_even(indicator_count):
             speculative_replacement[key] = paragraph
-            if not within_code_block: # found end
+            if not within_code_block:  # found end
                 paragraphs.update(speculative_replacement)
                 break
     return True
-
-

--- a/MAGSBS/pagenumbering.py
+++ b/MAGSBS/pagenumbering.py
@@ -13,14 +13,16 @@ import os
 from . import config, datastructures, mparser
 from .config import MetaInfo
 
+
 def add_page_number(path, line_number):
     """This function parses all page numbers from the given path and adds a new
     page number at the specified line. It parses all page numbers until this
     line and then decides what the next number is and whether it is roman or
     arabic (depending on its predecessors).
     It does not actually insert the new page number, but returns it, so that it can be inserted."""
-    with open(path, 'r', encoding='utf-8') as f:
+    with open(path, "r", encoding="utf-8") as f:
         return add_page_number_from_str(f.read(), line_number, path)
+
 
 def add_page_number_from_str(data, line_number, path=None):
     """This function parses all page numbers from the given string and adds a new
@@ -32,21 +34,26 @@ def add_page_number_from_str(data, line_number, path=None):
     mandatory, but strongly advised. It is used to load the lecture
     configuration for localisation."""
     paragraphs = mparser.file2paragraphs(data)
-    pagenumbers = mparser.extract_page_numbers_from_par(paragraphs,
-            ignore_after_lnum=line_number)
+    pagenumbers = mparser.extract_page_numbers_from_par(
+        paragraphs, ignore_after_lnum=line_number
+    )
     if not pagenumbers:
         if path:
             if os.path.isfile(path):
                 path = os.path.dirname(os.path.abspath(path))
             conf = config.ConfFactory().get_conf_instance(path)
-        else: # fall back to default configuration
+        else:  # fall back to default configuration
             conf = config.LectureMetaData(path)
         translator = config.Translate()
         translator.set_language(conf[MetaInfo.Language])
         return datastructures.PageNumber(translator.get_translation("page"), 1)
     else:
-        return datastructures.PageNumber(pagenumbers[-1].identifier,
-                pagenumbers[-1].number+1, pagenumbers[-1].arabic)
+        return datastructures.PageNumber(
+            pagenumbers[-1].identifier,
+            pagenumbers[-1].number + 1,
+            pagenumbers[-1].arabic,
+        )
+
 
 def check_page_numbering(pnums):
     """This function checks for monotonic increasing page numbering within a
@@ -62,17 +69,16 @@ def check_page_numbering(pnums):
     """
     if not pnums:
         return tuple()
-    errorneous = [] # tuple of page number object and expected page number (as number)
-    prev = pnums[0] # previous
+    errorneous = []  # tuple of page number object and expected page number (as number)
+    prev = pnums[0]  # previous
     for cur in pnums[1:]:
         # if previous page number was errorneous and the style is unchanged:
-        if prev.arabic == cur.arabic: # same style
-            if errorneous and errorneous[-1][0] == prev: # already error found
-                errorneous.append((cur, errorneous[-1][1]+1))
+        if prev.arabic == cur.arabic:  # same style
+            if errorneous and errorneous[-1][0] == prev:  # already error found
+                errorneous.append((cur, errorneous[-1][1] + 1))
             elif prev.number != (cur.number - 1):
                 errorneous.append((cur, prev.number + 1))
-        else: # different style, ignore
+        else:  # different style, ignore
             pass
         prev = cur
     return errorneous
-

--- a/MAGSBS/pandoc/contentfilter.py
+++ b/MAGSBS/pandoc/contentfilter.py
@@ -2,7 +2,7 @@
 # details.
 #
 # (c) 2016-2018 Sebastian Humenda <shumenda |at|gmx |dot| de>
-#pylint: disable=unused-argument
+# pylint: disable=unused-argument
 """
 To convert lecture material and books taillored to our requirements, content
 filters have been written, stored in this module. A content filter is a function
@@ -26,53 +26,57 @@ from .. import config
 from ..errors import MathError, SubprocessError
 
 
-html = lambda text: pandocfilters.RawBlock('html', text)
+html = lambda text: pandocfilters.RawBlock("html", text)
 
-#pylint: disable=inconsistent-return-statements
+# pylint: disable=inconsistent-return-statements
 def page_number_extractor(key, value, fmt, meta):
     """Scan all paragraphs for those starting with || to parse it for page
     numbering information."""
-    if not (fmt == 'html' or fmt == 'html5' or fmt == 'epub'):
+    if not (fmt == "html" or fmt == "html5" or fmt == "epub"):
         return
-    if key == 'Para' and value:
+    if key == "Para" and value:
         # find first obj with content (line breaks don't have this)
         text = None
         for obj in value:
-            if 'c' in obj:
-                text = obj['c']
+            if "c" in obj:
+                text = obj["c"]
                 break
         if text is None:
-            return # no content in Paragraph - ignore
+            return  # no content in Paragraph - ignore
         # first chunk of paragraph must be str and contain '||'
-        if isinstance(text, str) and text.startswith('||'):
-            text = pandocfilters.stringify(value) # get whole text of page number
+        if isinstance(text, str) and text.startswith("||"):
+            text = pandocfilters.stringify(value)  # get whole text of page number
             pnum = config.PAGENUMBERING_PATTERN.search(text)
             if pnum:
                 # strip the first ||
                 text = text[2:].lstrip().rstrip()
-                if fmt == 'epub':
-                    return html('<p class="pagebreak"><span id="p{0}">{1}</span></p>'.format(
-                        pnum.groups()[1], text))
-                return html('<p><span id="p{0}">{1}</span></p>'.format(
-                    pnum.groups()[1], text))
+                if fmt == "epub":
+                    return html(
+                        '<p class="pagebreak"><span id="p{0}">{1}</span></p>'.format(
+                            pnum.groups()[1], text
+                        )
+                    )
+                return html(
+                    '<p><span id="p{0}">{1}</span></p>'.format(pnum.groups()[1], text)
+                )
 
 
 def html_link_converter(key, value, fmt, meta, modify_ast=True):
     """Change file extension of links from .md to .html to make the linking more
     format-independent."""
-    if not (fmt == 'html' or fmt == 'html5'):
+    if not (fmt == "html" or fmt == "html5"):
         return
-    if key == 'Link' and value:
+    if key == "Link" and value:
         link = value[-1][0]  # last element contains the actual link
         # filter out all absolute links
-        if not link or ':' in link:
+        if not link or ":" in link:
             return
         if isinstance(link, str):
-            link_parts = link.split('#', 1)  # split in # once
+            link_parts = link.split("#", 1)  # split in # once
             if not link_parts[0]:
                 return
-            link_parts[0] = os.path.splitext(link_parts[0])[0] + '.html'
-            value[-1][0] = '#'.join(link_parts)
+            link_parts[0] = os.path.splitext(link_parts[0])[0] + ".html"
+            value[-1][0] = "#".join(link_parts)
 
 
 def epub_link_converter(key, value, fmt, meta, modify_ast=True):
@@ -81,22 +85,22 @@ def epub_link_converter(key, value, fmt, meta, modify_ast=True):
     meta structure: { 'chapter': int, 'ids': dict }
     the 'ids' dict contains the ids of the links as key and
     the chapter as key"""
-    if fmt != 'epub' or not value:
+    if fmt != "epub" or not value:
         return
-    if key == 'Link':
+    if key == "Link":
         link = value[-1][0]  # last element contains the actual link
         # filter out all absolute links
-        if not link or ':' in link:
+        if not link or ":" in link:
             return
         if isinstance(link, str):
-            link_parts = link.split('#', 1)  # split in # once
+            link_parts = link.split("#", 1)  # split in # once
             if len(link_parts) < 2 or not link_parts[0] or not link_parts[1]:
                 return
             # check if link id is within 'ids' dict of meta
-            if link_parts[1] in meta['ids']:
+            if link_parts[1] in meta["ids"]:
                 # set chapter from meta
-                link_parts[0] = 'ch{:03d}.xhtml'.format(meta['ids'][link_parts[1]])
-                value[-1][0] = '#'.join(link_parts)
+                link_parts[0] = "ch{:03d}.xhtml".format(meta["ids"][link_parts[1]])
+                value[-1][0] = "#".join(link_parts)
 
 
 def epub_convert_header_ids(key, value, fmt, url_prefix, modify_ast=True):
@@ -104,38 +108,41 @@ def epub_convert_header_ids(key, value, fmt, url_prefix, modify_ast=True):
     to images with the image_ prefix.
     Header: e.g. 'header_id' -> 'k02_header_id'
     Image: e.g. 'image_id' -> 'image_k02_image_id'"""
-    if fmt != 'epub' or not value:
+    if fmt != "epub" or not value:
         return
     # prepend all header IDs with the chapter
-    if key == 'Header':
-        value[1][0] = '_'.join([url_prefix, value[1][0]])
-    elif key == 'Link':
+    if key == "Header":
+        value[1][0] = "_".join([url_prefix, value[1][0]])
+    elif key == "Link":
         link = value[-1][0]  # last element contains the actual link
         # filter out all absolute links
-        if not link or ':' in link:
+        if not link or ":" in link:
             return
         if isinstance(link, str):
-            link_parts = link.split('#', 1)  # split in # once
-            if len(link_parts) < 2 or not link_parts[1]: # return if there is no anchor
+            link_parts = link.split("#", 1)  # split in # once
+            if len(link_parts) < 2 or not link_parts[1]:  # return if there is no anchor
                 return
-            link_parts[1] = '_'.join([url_prefix, link_parts[1]])
+            link_parts[1] = "_".join([url_prefix, link_parts[1]])
             # check if link is attached to an image and update it
-            if (isinstance(value[1][0], dict) and value[1][0]['t']
-                    and value[1][0]['t'] == 'Image'):
-                link_parts[1] = 'image_{}'.format(link_parts[1])
-            value[-1][0] = '#'.join(link_parts)
+            if (
+                isinstance(value[1][0], dict)
+                and value[1][0]["t"]
+                and value[1][0]["t"] == "Image"
+            ):
+                link_parts[1] = "image_{}".format(link_parts[1])
+            value[-1][0] = "#".join(link_parts)
 
 
 def epub_convert_image_header_ids(key, value, fmt, meta, modify_ast=True):
     """prepends all image header IDs with 'image_'"""
-    if key == 'Header' and value:
-        value[1][0] = 'image_{}'.format(value[1][0])
+    if key == "Header" and value:
+        value[1][0] = "image_{}".format(value[1][0])
 
 
 def epub_remove_images_from_toc(key, value, fmt, meta):
     """Converts all headers to be just paragraphs so that images are not
     added to toc."""
-    if fmt != 'epub':
+    if fmt != "epub":
         return
     # convert all headres to raw blocks
     # paragrapf contains 3 attributes:
@@ -143,11 +150,11 @@ def epub_remove_images_from_toc(key, value, fmt, meta):
     # class: "header" or "header pagebrak" for correct display
     # data-level: header level from original header
     # <p id="image_id" class="header" data-level="2">Image</p>
-    if key == 'Header' and value:
+    if key == "Header" and value:
         # find first obj with content (line breaks don't have this)
         text = None
         header_level = 0
-        _id = ''
+        _id = ""
         # extract all relevant values
         for obj in value:
             if isinstance(obj, int):
@@ -157,23 +164,23 @@ def epub_remove_images_from_toc(key, value, fmt, meta):
                     if isinstance(inner_obj, str):
                         _id = inner_obj
                     elif isinstance(inner_obj, dict):
-                        if 'c' in inner_obj:
-                            text = inner_obj['c']
+                        if "c" in inner_obj:
+                            text = inner_obj["c"]
         # check if everything is there
-        if text is None or header_level == 0 or _id == '':
-            return # no valid content
+        if text is None or header_level == 0 or _id == "":
+            return  # no valid content
         # create raw block
         if isinstance(text, str):
             text = pandocfilters.stringify(value)
             return html(
                 '<p id="{0}" class="{1}" data-level="{2}">{3}</p>'.format(
                     _id,
-                    'header pagebreak' if header_level == 1 else 'header',
+                    "header pagebreak" if header_level == 1 else "header",
                     header_level,
-                    text
+                    text,
                 )
             )
- 
+
 
 def epub_update_image_location(key, value, fmt, url_prefix, modify_ast=True):
     """Updates all image references (referenced relative to the lecture root) so
@@ -181,35 +188,35 @@ def epub_update_image_location(key, value, fmt, url_prefix, modify_ast=True):
     E.g:
     before: bilder/image.png
     after: k02/bilder/image.png"""
-    if fmt != 'epub':
+    if fmt != "epub":
         return
-    if key == 'Image' and value:
+    if key == "Image" and value:
         image_url = value[-1][0]
-        if not image_url or image_url[0] == '/' or ':' in image_url:
+        if not image_url or image_url[0] == "/" or ":" in image_url:
             return
-        value[-1][0] = '/'.join([url_prefix, image_url])  # dont use os.path
+        value[-1][0] = "/".join([url_prefix, image_url])  # dont use os.path
 
 
 def epub_create_back_link_ids(key, value, fmt, meta, modify_ast=True):
     """Adds an id with the suffix _back to each link to be used as anchor for
     possible back links."""
-    if fmt != 'epub' or not value:
+    if fmt != "epub" or not value:
         return
     # add an id to all relative links to jump back to
-    elif key == 'Link':
+    elif key == "Link":
         link = value[-1][0]  # last element contains the actual link
         # filter out all absolute links
-        if not link or ':' in link:
+        if not link or ":" in link:
             return
         if isinstance(link, str):
             # get target and use it as id for the link
             # the virst element of value contains the link id which is empty
             # by default. It is just needed to add the id there.
             # e.g.: <a id="target_id_back" href="target_id">Target</a>
-            link_parts = link.split('#', 1)  # split in # once
+            link_parts = link.split("#", 1)  # split in # once
             if len(link_parts) < 2 or not link_parts[1]:
                 return
-            value[0][0] = '{}_back'.format(link_parts[1])
+            value[0][0] = "{}_back".format(link_parts[1])
 
 
 def epub_create_back_links(key, value, fmt, meta):
@@ -218,38 +225,39 @@ def epub_create_back_links(key, value, fmt, meta):
     meta structure: { 'chapter': int, 'ids': dict }
     the 'ids' dict contains the ids of the links as key and
     the chapter as key"""
-    if fmt != 'epub':
+    if fmt != "epub":
         return
-    # header from image descriptions are within a RawBlock 
+    # header from image descriptions are within a RawBlock
     # due to a previous filter
     # before: <p id="image_id", class="header" data-level="2">Image Id</p>
     # after:
     # <p id="image_id", class="header" data-level="2">
     #   <a href="image_id_back">Image Id</a>
     # </p>
-    if key == 'RawBlock' and value[0] == 'html':
+    if key == "RawBlock" and value[0] == "html":
         # get the html code from the raw block and parse it
         try:
             xml = minidom.parseString(value[1])
         except ExpatError:
-            return # no valid xml!
+            return  # no valid xml!
         # get the element to be updated
         content = xml.getElementsByTagName("p")
         if not content:
             return
         content = content[0]
         # check if the html code meets the requirements to be an image header
-        if not all(x in content.attributes for x in ['id', 'class']):
+        if not all(x in content.attributes for x in ["id", "class"]):
             return
-        anchor_id = content.attributes['id'].value + '_back'
-        if not anchor_id in meta['ids']:
+        anchor_id = content.attributes["id"].value + "_back"
+        if not anchor_id in meta["ids"]:
             return
         # get the id to put it later in the link to go back
         # the original link will have a matching id
         # id: 'image_id' -> back link: '#image_id_back'
-        link = xml.createElement('a')
-        link.setAttribute('href', 'ch{:03d}.xhtml#{}'.format(
-            meta['ids'][anchor_id], anchor_id))
+        link = xml.createElement("a")
+        link.setAttribute(
+            "href", "ch{:03d}.xhtml#{}".format(meta["ids"][anchor_id], anchor_id)
+        )
         text = xml.createTextNode(content.firstChild.toxml())
         link.appendChild(text)
         content.replaceChild(link, content.firstChild)
@@ -261,112 +269,124 @@ def epub_collect_ids(key, value, fmt, meta):
     meta structure: { 'chapter': int, 'ids': dict }
     the 'ids' dict contains the ids of the links as key and
     the chapter as key"""
-    if fmt != 'epub' or not value:
+    if fmt != "epub" or not value:
         return
     # if header level is 1 a new chapter is created for epub. It is needed
     # to count the chapters to create correct links.
-    if key == 'Header':
+    if key == "Header":
         if value[0] == 1:  # first element contains header level (1 == <h1>)
-            meta['chapter'] += 1
+            meta["chapter"] += 1
         # value[1][0] is id in AST for Header
-        meta['ids'][value[1][0]] = meta['chapter']
-    elif key == 'Link':
+        meta["ids"][value[1][0]] = meta["chapter"]
+    elif key == "Link":
         # value[0][0] is id in AST for Link
-        meta['ids'][value[0][0]] = meta['chapter']
-    elif key == 'RawBlock' and value[0] == 'html':
+        meta["ids"][value[0][0]] = meta["chapter"]
+    elif key == "RawBlock" and value[0] == "html":
         # get the html code from the raw block and parse it
         try:
             xml = minidom.parseString(value[1])
         except ExpatError:
-            return # no valid xml!
+            return  # no valid xml!
         # get the element to be updated
         content = xml.getElementsByTagName("p")
         if not content:
             return
         content = content[0]
         # check if there is an id
-        if not 'id' in content.attributes:
+        if not "id" in content.attributes:
             return
-        meta['ids'][content.attributes['id'].value] = meta['chapter']
+        meta["ids"][content.attributes["id"].value] = meta["chapter"]
 
 
 def epub_unnumbered_toc(key, value, fmt, meta, modify_ast=True):
     """marks all headlines of appendix to be unnumbered in toc."""
-    if fmt != 'epub' or not value:
+    if fmt != "epub" or not value:
         return
-    if key == 'Header':
+    if key == "Header":
         value[1][1].append("unnumbered")  # append unnumbered class to header
+
 
 def suppress_captions(key, value, fmt, meta, modify_ast=True):
     """Images on a paragraph of its own get a caption, suppress that."""
-    if modify_ast and not fmt in ['html', 'html5']:
+    if modify_ast and not fmt in ["html", "html5"]:
         return
-    if key == 'Image':
+    if key == "Image":
         # value consists of a list with the last item being a list again; this
         # list contains (path, 'fig:'), if the latter is removed, caption
         # vanishes:
-        value[-1][1] = ''
+        value[-1][1] = ""
+
 
 def heading_extractor(key, value, fmt, meta, modify_ast=False):
     """Extract all headings from the JSon AST."""
-    if key == 'Header':
+    if key == "Header":
         # value[0] is the heading level
         return (value[0], pandocfilters.stringify(value))
 
 
 def file2json_ast(file_name):
     """Read in specified file and return a JSON AST."""
-    with open(file_name, encoding='utf-8') as file:
+    with open(file_name, encoding="utf-8") as file:
         return load_pandoc_ast(file.read())
+
 
 def load_pandoc_ast(text):
     """Run pandoc on given document and return parsed JSON AST."""
-    command = ['pandoc', '-f', 'markdown', '-t', 'json']
-    proc = subprocess.Popen(command, stdin=subprocess.PIPE,
-                            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    command = ["pandoc", "-f", "markdown", "-t", "json"]
+    proc = subprocess.Popen(
+        command, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+    )
     data = proc.communicate(text.encode(sys.getdefaultencoding()))
     ret = proc.wait()
     if ret:
-        error = '\n'.join([e.decode(sys.getdefaultencoding())
-                           for e in data])
-        raise SubprocessError(' '.join(command),
-                              "Pandoc gave error status %s: %s" % (ret, error))
+        error = "\n".join([e.decode(sys.getdefaultencoding()) for e in data])
+        raise SubprocessError(
+            " ".join(command), "Pandoc gave error status %s: %s" % (ret, error)
+        )
     text = data[0].decode(sys.getdefaultencoding())
     return json.loads(text)
 
 
-#pylint: disable=too-few-public-methods
+# pylint: disable=too-few-public-methods
 class Text:
     """A text chunk."""
+
     def __init__(self, text):
         self.text = text
+
     def __repr__(self):
-        return 'T<%s>' % self.text
+        return "T<%s>" % self.text
+
     def __str__(self):
         return self.text
 
-#pylint: disable=too-few-public-methods
+
+# pylint: disable=too-few-public-methods
 class Formula:
     """A formula, represented as displaymath by __str__."""
+
     def __init__(self, formula):
         self.formula = formula
+
     def __str__(self):
-        return '$$%s$$' % self.formula
+        return "$$%s$$" % self.formula
+
     def __repr__(self):
-        return 'F<%s>' % self.__str__()
+        return "F<%s>" % self.__str__()
 
 
 def get_title(json_ast):
     """Get title from AST"""
-    nodes_to_visit = json_ast['blocks'] # content of document without meta info
+    nodes_to_visit = json_ast["blocks"]  # content of document without meta info
     for node in nodes_to_visit:
         if isinstance(node, list):
             nodes_to_visit.extend(node)
         elif isinstance(node, dict):
             # node dictionaries have keys t (type) and c (content)
-            if 't' in node and node.get('t') == 'Header' and 'c' in node:
-                if node['c'][0] == 1: # level 1 heading
-                    return pandocfilters.stringify(node['c'])
+            if "t" in node and node.get("t") == "Header" and "c" in node:
+                if node["c"][0] == 1:  # level 1 heading
+                    return pandocfilters.stringify(node["c"])
+
 
 def convert_formulas(conversion_file, img_dir, ast):
     """This filter extracts all formulas from the given Pandoc AST, converts
@@ -379,22 +399,24 @@ def convert_formulas(conversion_file, img_dir, ast):
     >>> convert_formulas('k01/k01.md', 'bilder', my_ast)"""
     formulas = gleetex.pandoc.extract_formulas(ast)
     base_path = os.path.dirname(conversion_file)
-    conv = gleetex.cachedconverter.CachedConverter(base_path, True,
-            encoding="UTF-8", img_dir=img_dir)
+    conv = gleetex.cachedconverter.CachedConverter(
+        base_path, True, encoding="UTF-8", img_dir=img_dir
+    )
     conv.set_replace_nonascii(True)
     try:
         conv.convert_all(formulas)
     except gleetex.cachedconverter.ConversionException as gle:
-        raise MathError(_('Incorrect formula: {reason}').format(
-            reason=gle.cause), gle.formula,
-                        formula_count=gle.formula_count) from None
+        raise MathError(
+            _("Incorrect formula: {reason}").format(reason=gle.cause),
+            gle.formula,
+            formula_count=gle.formula_count,
+        ) from None
 
     # an converted image has information like image depth and height and hence
     # the data structure is different
     formulas = [conv.get_data_for(eqn, style) for _p, style, eqn in formulas]
-    with gleetex.htmlhandling.HtmlImageFormatter(base_path)  as img_fmt:
+    with gleetex.htmlhandling.HtmlImageFormatter(base_path) as img_fmt:
         img_fmt.set_exclude_long_formulas(True)
         img_fmt.set_replace_nonascii(True)
         # this alters the AST reference, so no return value required
-        gleetex.pandoc.replace_formulas_in_ast(img_fmt, ast['blocks'],
-                                               formulas)
+        gleetex.pandoc.replace_formulas_in_ast(img_fmt, ast["blocks"], formulas)

--- a/MAGSBS/pandoc/converter.py
+++ b/MAGSBS/pandoc/converter.py
@@ -10,7 +10,7 @@ template for additional meta data in the output document(s).
 Converter to different output formats can be easily added by adding the class to
 the field converters of the pandoc class.
 """
-#pylint: disable=multiple-imports
+# pylint: disable=multiple-imports
 
 import os
 from .formats import ConversionProfile, OutputFormat
@@ -26,6 +26,7 @@ from .. import filesystem
 
 ACTIVE_CONVERTERS = [HtmlConverter, EpubConverter]
 
+
 def get_lecture_root(some_file):
     """Return lecture root for a file or raise exception if it cannot be
     determined."""
@@ -39,44 +40,51 @@ def get_lecture_root(some_file):
     if path and common.is_lecture_root(path):
         return path
     else:
-        raise errors.StructuralError(("Could not guess the lecture root "
-            "for this file"), path)
+        raise errors.StructuralError(
+            ("Could not guess the lecture root " "for this file"), path
+        )
 
 
 class Pandoc:
     """Abstract the translation by pandoc into a class which add meta-information
 to the output, handles errors and checks for the correct encoding.
 """
+
     def __init__(self, conf=None, root_path=None):
         self.converters = ACTIVE_CONVERTERS
-        self.__conf = (config.ConfFactory().get_conf_instance(os.getcwd())
-                if not conf else conf)
-        self.__meta_data = {k.name: v  for k, v in self.__conf.items()}
-        self.__meta_data['path'] = None
+        self.__conf = (
+            config.ConfFactory().get_conf_instance(os.getcwd()) if not conf else conf
+        )
+        self.__meta_data = {k.name: v for k, v in self.__conf.items()}
+        self.__meta_data["path"] = None
         self.__conv_profile = ConversionProfile.Blind
         self.__output_format = OutputFormat.Html
         self.__root_path = root_path
 
     def get_formatter_for_format(self, format_):
         """Get converter object."""
-        try: # get new instance
-            return next(filter(lambda converter: \
-                    converter.PANDOC_FORMAT_NAME == format_,
-                    ACTIVE_CONVERTERS))(
-                        self.__meta_data,
-                        self.__conf[MetaInfo.Language]
-                    )
+        try:  # get new instance
+            return next(
+                filter(
+                    lambda converter: converter.PANDOC_FORMAT_NAME == format_,
+                    ACTIVE_CONVERTERS,
+                )
+            )(self.__meta_data, self.__conf[MetaInfo.Language])
         except StopIteration:
-            supported_formats = ', '.join(map(lambda c: c.PANDOC_FORMAT_NAME, \
-                self.converters))
-            raise NotImplementedError(("The configured format {} is not "
-                "supported at the moment. Supported formats: {}").format(
-                format, supported_formats))
+            supported_formats = ", ".join(
+                map(lambda c: c.PANDOC_FORMAT_NAME, self.converters)
+            )
+            raise NotImplementedError(
+                (
+                    "The configured format {} is not "
+                    "supported at the moment. Supported formats: {}"
+                ).format(format, supported_formats)
+            )
 
     def __update_metadata(self, conf):
         """Set latest meta data from given configuration."""
-        self.__meta_data = {key.name: val  for key, val in conf.items()}
-        self.__meta_data['path'] = conf.get_path()
+        self.__meta_data = {key.name: val for key, val in conf.items()}
+        self.__meta_data["path"] = conf.get_path()
 
     @staticmethod
     def get_cache(files):
@@ -96,15 +104,19 @@ to the output, handles errors and checks for the correct encoding.
                     raise e from None
             cache = datastructures.FileCache(file_walker.walk())
         else:
-            raise TypeError(("files argument must be either a list or tuple of "
-                "file names or a FileCache object"))
+            raise TypeError(
+                (
+                    "files argument must be either a list or tuple of "
+                    "file names or a FileCache object"
+                )
+            )
         return (cache, files)
 
     def convert_files(self, files):
         """converts a list of files. They should share all the meta data, except
         for the title. All files must be part of one lecture.
         `files` can be either a cache object or a list of files to convert."""
-        converter = None # declare in outer scope for finally
+        converter = None  # declare in outer scope for finally
         converter = self.get_formatter_for_format(self.__output_format.value)
         converter.set_meta_data(self.__meta_data)
         converter.setup()
@@ -113,12 +125,10 @@ to the output, handles errors and checks for the correct encoding.
 
     def set_conversion_profile(self, profile):
         if not isinstance(profile, ConversionProfile):
-            raise TypeError("Expected profile of type " + \
-                    type(ConversionProfile))
+            raise TypeError("Expected profile of type " + type(ConversionProfile))
         self.__conv_profile = profile
 
     def set_output_format(self, format_):
         if not isinstance(format_, OutputFormat):
-            raise TypeError("Expected format of type " + \
-                    type(OutputFormat))
+            raise TypeError("Expected format of type " + type(OutputFormat))
         self.__output_format = format_

--- a/MAGSBS/pandoc/formats.py
+++ b/MAGSBS/pandoc/formats.py
@@ -15,28 +15,31 @@ from .. import config, common, datastructures, errors, mparser
 
 class ConversionProfile(enum.Enum):
     """Defines the enums for the conversion depending on the the impairment."""
-    Blind = 'blind'
-    VisuallyImpairedDefault = 'vid'
+
+    Blind = "blind"
+    VisuallyImpairedDefault = "vid"
 
     @staticmethod
     def from_string(string):
         for profile in ConversionProfile:
             if profile.value == string:
                 return profile
-        known = ', '.join(x.value for x in ConversionProfile)
+        known = ", ".join(x.value for x in ConversionProfile)
         raise ValueError("Unknown profile, known profiles: " + known)
+
 
 class OutputFormat(enum.Enum):
     """Defines the enums for the output format."""
-    Html = 'html'
-    Epub = 'epub'
+
+    Html = "html"
+    Epub = "epub"
 
     @staticmethod
     def from_string(string):
         for format_ in OutputFormat:
             if format_.value == string:
                 return format_
-        known = ', '.join(x.value for x in OutputFormat)
+        known = ", ".join(x.value for x in OutputFormat)
         raise ValueError("Unknown output format, known formats: " + known)
 
     def get_file_extension(self):
@@ -45,7 +48,7 @@ class OutputFormat(enum.Enum):
         return self.value
 
 
-class OutputGenerator():
+class OutputGenerator:
     """Base class for document output generators. The actual conversion doesn't
 take place in this class. The conversion method receives a Pandoc (JSON) AST and
 transforms it, as required. The transformed AST is returned.
@@ -64,12 +67,13 @@ General usage:
 # clean up, e.g. deletion of templates. Should be executed even if gen.convert()
 # threw an error
 gen.cleanup()."""
-    FILE_EXTENSION = 'None'
-    PANDOC_FORMAT_NAME = 'plain'
+
+    FILE_EXTENSION = "None"
+    PANDOC_FORMAT_NAME = "plain"
     # json content filters:
     CONTENT_FILTERS = []
     # recognize chapter prefixes in paths, e.g. "anh01" for appendix chapter one
-    IS_CHAPTER = re.compile(r'^%s\d+\.md$' % '|'.join(common.VALID_FILE_BGN))
+    IS_CHAPTER = re.compile(r"^%s\d+\.md$" % "|".join(common.VALID_FILE_BGN))
 
     def __init__(self, meta, language):
         self.__meta = meta
@@ -119,28 +123,37 @@ def execute(args, stdin=None, cwd=None):
     text = None
     proc = None
     text = None
-    cwd = (cwd if cwd else '.')
-    text = ''
+    cwd = cwd if cwd else "."
+    text = ""
     try:
         if stdin:
-            proc = subprocess.Popen(args, stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE, stdin=subprocess.PIPE, cwd=cwd)
+            proc = subprocess.Popen(
+                args,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                stdin=subprocess.PIPE,
+                cwd=cwd,
+            )
             text = proc.communicate(stdin.encode(datastructures.get_encoding()))
         else:
-            proc = subprocess.Popen(args, stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE, cwd=cwd)
+            proc = subprocess.Popen(
+                args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=cwd
+            )
             text = proc.communicate()
     except FileNotFoundError as e:
-        msg = '%s:_: %s %s ' %(args[0], str(e), text)
+        msg = "%s:_: %s %s " % (args[0], str(e), text)
         raise errors.SubprocessError(args, msg)
     if not proc:
-        raise ValueError("No subprocess handle exists, even though it " + \
-                "should. That's a bug to be reported.")
+        raise ValueError(
+            "No subprocess handle exists, even though it "
+            + "should. That's a bug to be reported."
+        )
     ret = proc.wait()
     if ret:
-        msg = '\n'.join(map(datastructures.decode, text))
+        msg = "\n".join(map(datastructures.decode, text))
         raise errors.SubprocessError(args, msg)
     return datastructures.decode(text[0])
+
 
 def remove_temp(fn):
     if fn is None:
@@ -150,46 +163,54 @@ def remove_temp(fn):
             os.remove(fn)
         except OSError:
             common.WarningRegistry().register_warning(
-            "Couldn't remove tempfile", path=fn)
+                "Couldn't remove tempfile", path=fn
+            )
+
 
 def __handle_gladtex_error(error, file_path, dirname):
     """Retrieve formula position from GladTeX' error output, match it
     against the formula of the Markdown document and report it to the
     user.
     Note: file_path is relative to dirname, so both is required."""
-    file_path = os.path.join(dirname, file_path) # full path is better
+    file_path = os.path.join(dirname, file_path)  # full path is better
     try:
-        details = dict(line.split(': ', 1) for line in error.message.split('\n')
-            if ': ' in line)
+        details = dict(
+            line.split(": ", 1) for line in error.message.split("\n") if ": " in line
+        )
     except ValueError as e:
         # output was not formatted as expected, report that
-        msg = "couldn't parse GladTeX output: %s\noutput: %s" % \
-            (str(e), error.message)
+        msg = "couldn't parse GladTeX output: %s\noutput: %s" % (str(e), error.message)
         return errors.SubprocessError(error.command, msg, path=dirname)
-    if details and 'Number' in details and 'Message' in details:
-        number = int(details['Number'])
-        with open(file_path, 'r', encoding='utf-8') as file:
-            paragraphs = mparser.rm_codeblocks(mparser.file2paragraphs(
-                file.read().split('\n')))
+    if details and "Number" in details and "Message" in details:
+        number = int(details["Number"])
+        with open(file_path, "r", encoding="utf-8") as file:
+            paragraphs = mparser.rm_codeblocks(
+                mparser.file2paragraphs(file.read().split("\n"))
+            )
             formulas = mparser.parse_formulas(paragraphs)
         try:
-            pos = list(formulas.keys())[number-1]
+            pos = list(formulas.keys())[number - 1]
         except IndexError:
             # if improperly closed maths environments eixst, formulas cannot
             # be counted; although there's somewhere a LaTeX error which
             # we're trying to report, the improper maths environments HAVE
             # to reported and fixed first
-            raise errors.SubprocessError(error.command, _(
+            raise errors.SubprocessError(
+                error.command,
+                _(
                     "LaTeX reported an error while converting a fomrula. "
                     "Unfortunately, improperly closed formula environments "
                     "exist, therefore it cannot be determined which formula "
                     "was errorneous. Please re-read the document and fix "
-                    "any unclosed formula environments."), file_path)
+                    "any unclosed formula environments."
+                ),
+                file_path,
+            )
 
         # get LaTeX error output
-        msg = details['Message'].rstrip().lstrip()
-        msg = 'formula: {}\n{}'.format(list(formulas.values())[number-1], msg)
+        msg = details["Message"].rstrip().lstrip()
+        msg = "formula: {}\n{}".format(list(formulas.values())[number - 1], msg)
         e = errors.SubprocessError(error.command, msg, path=file_path)
-        e.line = '{}, {}'.format(*pos)
+        e.line = "{}, {}".format(*pos)
         return e
     return error

--- a/MAGSBS/pandoc/output_formats/epub.py
+++ b/MAGSBS/pandoc/output_formats/epub.py
@@ -56,42 +56,53 @@ lang: {Language}
 ...
 """
 
+
 class EpubConverter(OutputGenerator):
     """HTML output format generator. For documentation see super class;."""
-    PANDOC_FORMAT_NAME = 'epub'
-    FILE_EXTENSION = 'epub'
-    CONTENT_FILTERS = [contentfilter.page_number_extractor,
-                       contentfilter.epub_create_back_link_ids,
-                       contentfilter.epub_collect_ids,
-                       contentfilter.epub_link_converter,
-                       contentfilter.epub_create_back_links]
-    IMAGE_CONTENT_FILTERS = [contentfilter.epub_convert_image_header_ids,
-                             contentfilter.epub_remove_images_from_toc]
-    CHAPTER_CONTENT_FILTERS = [contentfilter.epub_convert_header_ids,
-                               contentfilter.epub_update_image_location]
+
+    PANDOC_FORMAT_NAME = "epub"
+    FILE_EXTENSION = "epub"
+    CONTENT_FILTERS = [
+        contentfilter.page_number_extractor,
+        contentfilter.epub_create_back_link_ids,
+        contentfilter.epub_collect_ids,
+        contentfilter.epub_link_converter,
+        contentfilter.epub_create_back_links,
+    ]
+    IMAGE_CONTENT_FILTERS = [
+        contentfilter.epub_convert_image_header_ids,
+        contentfilter.epub_remove_images_from_toc,
+    ]
+    CHAPTER_CONTENT_FILTERS = [
+        contentfilter.epub_convert_header_ids,
+        contentfilter.epub_update_image_location,
+    ]
     BACKMATTER_CONTENT_FILTERS = [contentfilter.epub_unnumbered_toc]
     SPECIAL_MD_CONTENT_FILTERS = [contentfilter.epub_unnumbered_toc]
-    LECTURE_ORDER = ['titel',
-                     'info',
-                     'copyright',
-                     'frontmatter',
-                     'chapters',
-                     'backmatter',
-                     'images',
-                     'taktil']
-    SPECIAL_MD_FILES = ['titel', 'info', 'copyright', 'taktil']
+    LECTURE_ORDER = [
+        "titel",
+        "info",
+        "copyright",
+        "frontmatter",
+        "chapters",
+        "backmatter",
+        "images",
+        "taktil",
+    ]
+    SPECIAL_MD_FILES = ["titel", "info", "copyright", "taktil"]
 
     def __init__(self, meta, language):
-        if not shutil.which('pandoc'):
-            raise errors.SubprocessError(['pandoc'],
-                _('You need to have Pandoc installed.'))
+        if not shutil.which("pandoc"):
+            raise errors.SubprocessError(
+                ["pandoc"], _("You need to have Pandoc installed.")
+            )
 
         super().__init__(meta, language)
         self.css_path = None
 
     def setup(self):
         """Set up the EpubConverter. Prepare the css for later use."""
-        self.css_path = tempfile.mktemp() + '.css'
+        self.css_path = tempfile.mktemp() + ".css"
         with open(self.css_path, "w", encoding="utf-8") as file:
             file.write(CSS_TEMPLATE)
 
@@ -102,14 +113,14 @@ class EpubConverter(OutputGenerator):
 
     def convert(self, files, **kwargs):
         """See super class documentation."""
-        if 'path' not in kwargs:
-            raise ValueError('path needs to be specified to save epub.')
+        if "path" not in kwargs:
+            raise ValueError("path needs to be specified to save epub.")
         if not files:
             return
         file_info = EpubConverter.__generate_file_structure(files)
         try:
-            ast = self.__generate_ast(file_info, kwargs['path'])
-            self.__convert_document(ast, kwargs['path'])
+            ast = self.__generate_ast(file_info, kwargs["path"])
+            self.__convert_document(ast, kwargs["path"])
         except errors.MAGSBS_error as err:
             raise err
         finally:
@@ -119,8 +130,9 @@ class EpubConverter(OutputGenerator):
     def __handle_error(file_name, err):
         # set path for error
         if not err.path:
-            err.path = os.path.abspath(file_name).replace(os.getcwd(), '').\
-                    lstrip(os.sep)
+            err.path = (
+                os.path.abspath(file_name).replace(os.getcwd(), "").lstrip(os.sep)
+            )
         if not isinstance(err, errors.MathError):
             raise err
         # recover line and pos of formula
@@ -128,7 +140,7 @@ class EpubConverter(OutputGenerator):
         line, pos = list(eqns.keys())[err.formula_count - 1]
         err.line = line
         err.pos = pos
-        raise err from None # no TB here
+        raise err from None  # no TB here
 
     @staticmethod
     def __generate_file_structure(files):
@@ -142,17 +154,17 @@ class EpubConverter(OutputGenerator):
         for file_name in files:
             name = os.path.splitext(os.path.basename(file_name))[0]
             chapter = os.path.basename(os.path.dirname(file_name))
-            if name == 'bilder':
-                file_info['images'].append({'chapter': chapter, 'path': file_name})
-            elif name[:3] == 'anh':
-                file_info['backmatter'].append({'chapter': chapter, 'path': file_name})
-            elif name.startswith('v'):
-                file_info['frontmatter'].append({'chapter': chapter, 'path': file_name})
-            elif name.startswith('k'):
-                file_info['chapters'].append({'chapter': chapter, 'path': file_name})
+            if name == "bilder":
+                file_info["images"].append({"chapter": chapter, "path": file_name})
+            elif name[:3] == "anh":
+                file_info["backmatter"].append({"chapter": chapter, "path": file_name})
+            elif name.startswith("v"):
+                file_info["frontmatter"].append({"chapter": chapter, "path": file_name})
+            elif name.startswith("k"):
+                file_info["chapters"].append({"chapter": chapter, "path": file_name})
             elif name in file_info:
                 # if it's not in the dict the file is ignored (e.g. inhalt)
-                file_info[name].append({'chapter': chapter, 'path': file_name})
+                file_info[name].append({"chapter": chapter, "path": file_name})
         return file_info
 
     def __generate_ast(self, file_info, path):
@@ -160,65 +172,82 @@ class EpubConverter(OutputGenerator):
         ast = {}
         for key in self.LECTURE_ORDER:
             for entry in file_info[key]:
-                with open(entry['path'], 'r', encoding='utf-8') as file:
+                with open(entry["path"], "r", encoding="utf-8") as file:
                     json_ast = contentfilter.load_pandoc_ast(file.read())
                     try:
                         # this alters the Pandoc document AST -- no return required
                         contentfilter.convert_formulas(
                             path,
-                            os.path.join(os.path.dirname(entry['path']), 'bilder'),
-                            json_ast
+                            os.path.join(os.path.dirname(entry["path"]), "bilder"),
+                            json_ast,
                         )
                     except errors.MathError as err:
                         EpubConverter.__handle_error(path, err)
-                    self.__apply_filters(json_ast,
-                                         self.CHAPTER_CONTENT_FILTERS,
-                                         path,
-                                         os.path.dirname(entry['path']))
-                    if key == 'images':
-                        self.__apply_filters(json_ast,
-                                             self.IMAGE_CONTENT_FILTERS,
-                                             path)
-                    elif key == 'backmatter':
-                        self.__apply_filters(json_ast,
-                                             self.BACKMATTER_CONTENT_FILTERS,
-                                             path)
+                    self.__apply_filters(
+                        json_ast,
+                        self.CHAPTER_CONTENT_FILTERS,
+                        path,
+                        os.path.dirname(entry["path"]),
+                    )
+                    if key == "images":
+                        self.__apply_filters(json_ast, self.IMAGE_CONTENT_FILTERS, path)
+                    elif key == "backmatter":
+                        self.__apply_filters(
+                            json_ast, self.BACKMATTER_CONTENT_FILTERS, path
+                        )
                     elif key in self.SPECIAL_MD_FILES:
-                        self.__apply_filters(json_ast,
-                                             self.SPECIAL_MD_CONTENT_FILTERS,
-                                             path)
+                        self.__apply_filters(
+                            json_ast, self.SPECIAL_MD_CONTENT_FILTERS, path
+                        )
                     if ast:
-                        ast['blocks'].extend(json_ast['blocks'])
+                        ast["blocks"].extend(json_ast["blocks"])
                     else:
                         ast = json_ast
         meta_ast = contentfilter.load_pandoc_ast(
-            YAML_TEMPLATE.format(**self.get_meta_data()))
-        ast['meta'] = meta_ast['meta']
+            YAML_TEMPLATE.format(**self.get_meta_data())
+        )
+        ast["meta"] = meta_ast["meta"]
         return ast
 
-    #pylint: disable=too-many-locals
+    # pylint: disable=too-many-locals
     def __convert_document(self, json_ast, path):
         """Convert an ast. It takes a converter which takes
         actual care of the underlying format."""
         if not json_ast:
-            return # skip empty asts
+            return  # skip empty asts
         # meta data which is used in more than one filter
-        filter_meta = {'chapter': 1, 'ids': {}}
+        filter_meta = {"chapter": 1, "ids": {}}
         self.__apply_filters(json_ast, self.CONTENT_FILTERS, path, filter_meta)
-        outputf = EpubConverter.__format_filename(self.get_meta_data()['LectureTitle'] + \
-                  '.' + self.FILE_EXTENSION)
-        pandoc_args = ['-s', '-N',
-                       '--css={}'.format(self.css_path),
-                       '--toc-depth={}'.format(self.get_meta_data()['TocDepth']),
-                       '--resource-path="{}"'.format(os.getcwd())]
+        outputf = EpubConverter.__format_filename(
+            self.get_meta_data()["LectureTitle"] + "." + self.FILE_EXTENSION
+        )
+        pandoc_args = [
+            "-s",
+            "-N",
+            "--css={}".format(self.css_path),
+            "--toc-depth={}".format(self.get_meta_data()["TocDepth"]),
+            '--resource-path="{}"'.format(os.getcwd()),
+        ]
         # for 'blind' see __apply_filters, doesn't need a Pandoc argument
         if self.get_profile() is ConversionProfile.VisuallyImpairedDefault:
-            pandoc_args.append('--mathjax')
-        execute(['pandoc'] + pandoc_args + [
-            '-t', self.PANDOC_FORMAT_NAME,
-            '-f', 'json', '+RTS', '-K25000000', '-RTS', # increase stack size
-            '-o', outputf
-        ], stdin=json.dumps(json_ast), cwd=path)
+            pandoc_args.append("--mathjax")
+        execute(
+            ["pandoc"]
+            + pandoc_args
+            + [
+                "-t",
+                self.PANDOC_FORMAT_NAME,
+                "-f",
+                "json",
+                "+RTS",
+                "-K25000000",
+                "-RTS",  # increase stack size
+                "-o",
+                outputf,
+            ],
+            stdin=json.dumps(json_ast),
+            cwd=path,
+        )
 
     def __apply_filters(self, json_ast, filters, path, meta=None):
         """add MarkDown extensions with Pandoc filters"""
@@ -230,14 +259,18 @@ class EpubConverter(OutputGenerator):
             for filter_ in filters:
                 # reset chapter count for next filter which may count chapters
                 if isinstance(meta, dict):
-                    if 'chapter' in meta:
-                        meta['chapter'] = 1
+                    if "chapter" in meta:
+                        meta["chapter"] = 1
                 json_ast = pandocfilters.walk(json_ast, filter_, fmt, meta)
-        except KeyError as e: # API clash(?)
-            raise errors.StructuralError((
-                "Incompatible Pandoc API found, while "
-                "applying filter %s (ABI clash?).\nKeyError: %s"
-            ) % (filter.__name__, str(e)), path)
+        except KeyError as e:  # API clash(?)
+            raise errors.StructuralError(
+                (
+                    "Incompatible Pandoc API found, while "
+                    "applying filter %s (ABI clash?).\nKeyError: %s"
+                )
+                % (filter.__name__, str(e)),
+                path,
+            )
 
     @staticmethod
     def __format_filename(str_):
@@ -247,6 +280,7 @@ class EpubConverter(OutputGenerator):
          
         Note: this method may produce invalid filenames such as ``, `.` or `..`
         """
-        filename = ''.join(c for c in str_
-                           if c.isalpha() or c.isdigit() or c in ' _()-.')
+        filename = "".join(
+            c for c in str_ if c.isalpha() or c.isdigit() or c in " _()-."
+        )
         return filename

--- a/MAGSBS/pandoc/output_formats/html.py
+++ b/MAGSBS/pandoc/output_formats/html.py
@@ -14,7 +14,7 @@ from .. import contentfilter
 from ..formats import execute, remove_temp, ConversionProfile, OutputGenerator
 
 
-#pylint: disable=line-too-long
+# pylint: disable=line-too-long
 HTML_TEMPLATE = """<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"$if(lang)$ lang="$lang$" xml:lang="$lang$"$endif$>
 <head>
@@ -78,24 +78,28 @@ $endfor$
 
 class HtmlConverter(OutputGenerator):
     """HTML output format generator. For documentation see super class;."""
-    PANDOC_FORMAT_NAME = 'html'
-    FILE_EXTENSION = 'html'
-    CONTENT_FILTERS = [contentfilter.page_number_extractor,
-                    contentfilter.html_link_converter,
-                    contentfilter.suppress_captions]
+
+    PANDOC_FORMAT_NAME = "html"
+    FILE_EXTENSION = "html"
+    CONTENT_FILTERS = [
+        contentfilter.page_number_extractor,
+        contentfilter.html_link_converter,
+        contentfilter.suppress_captions,
+    ]
 
     def __init__(self, meta, language):
-        if not shutil.which('pandoc'):
-            raise errors.SubprocessError(['pandoc'],
-                _('You need to have Pandoc installed.'))
+        if not shutil.which("pandoc"):
+            raise errors.SubprocessError(
+                ["pandoc"], _("You need to have Pandoc installed.")
+            )
 
         super().__init__(meta, language)
         self.template_path = None
-        self.template_copy = HTML_TEMPLATE[:] # full copy
+        self.template_copy = HTML_TEMPLATE[:]  # full copy
 
     def setup(self):
         """Set up the HtmlConverter. Prepare the template for later use."""
-        self.template_path = tempfile.mktemp() + '.html'
+        self.template_path = tempfile.mktemp() + ".html"
         self.template_copy = self.get_template()
         with open(self.template_path, "w", encoding="utf-8") as file:
             file.write(self.template_copy)
@@ -105,42 +109,61 @@ class HtmlConverter(OutputGenerator):
         start_with_caps = lambda content: content[0].upper() + content[1:]
         data = HTML_TEMPLATE[:]
         meta = self.get_meta_data()
-        if 'title' in meta:
-            meta.pop('title') # title should not be replaced
+        if "title" in meta:
+            meta.pop("title")  # title should not be replaced
 
         # get translator object to translate certain phrases according to
         # configured language
         trans = config.Translate()
         trans.set_language(super().get_language())
-        annotation = start_with_caps(trans.get_translation('note of editor'))
-        frames = ['.frame:before { content: "%s: "; }' % \
-                    start_with_caps(trans.get_translation("frame")),
-                '.frame:after { content: "\\A %s"; }' % start_with_caps(trans \
-                    .get_translation("end of frame"))]
-        boxes = ['.box:before { content: "%s: "; }' % \
-                    trans.get_translation("box"),
-                '.box:after { content: "\\A %s"; }' % start_with_caps(trans \
-            .get_translation("end of box"))]
-        colours = {'black': '#000000;', 'blue': '#0000FF', 'brown': '#A52A2A',
-            'grey': '#A9A9A9', 'green': '#006400', 'orange': '#FF8C00',
-            'red': '#FF0000', 'violet': '#8A2BE2', 'yellow': '#FFFF00'}
+        annotation = start_with_caps(trans.get_translation("note of editor"))
+        frames = [
+            '.frame:before { content: "%s: "; }'
+            % start_with_caps(trans.get_translation("frame")),
+            '.frame:after { content: "\\A %s"; }'
+            % start_with_caps(trans.get_translation("end of frame")),
+        ]
+        boxes = [
+            '.box:before { content: "%s: "; }' % trans.get_translation("box"),
+            '.box:after { content: "\\A %s"; }'
+            % start_with_caps(trans.get_translation("end of box")),
+        ]
+        colours = {
+            "black": "#000000;",
+            "blue": "#0000FF",
+            "brown": "#A52A2A",
+            "grey": "#A9A9A9",
+            "green": "#006400",
+            "orange": "#FF8C00",
+            "red": "#FF0000",
+            "violet": "#8A2BE2",
+            "yellow": "#FFFF00",
+        }
         for name, rgb in colours.items():
-            frames.append('.frame.%s { border-color: %s; }' % (name, rgb))
-            frames.append('.frame.%s:before { content: "%s: "; }' % (name, \
-                start_with_caps(trans.get_translation('%s frame' % name))))
-            boxes.append('.box.%s { border-color: %s; }' % (name, rgb))
-            boxes.append('.box.%s:before { content: "%s: "; }' % \
-                (name, trans.get_translation('%s box' % name)))
+            frames.append(".frame.%s { border-color: %s; }" % (name, rgb))
+            frames.append(
+                '.frame.%s:before { content: "%s: "; }'
+                % (name, start_with_caps(trans.get_translation("%s frame" % name)))
+            )
+            boxes.append(".box.%s { border-color: %s; }" % (name, rgb))
+            boxes.append(
+                '.box.%s:before { content: "%s: "; }'
+                % (name, trans.get_translation("%s box" % name))
+            )
 
         try:
-            return data.format(annotation=annotation,
-                    frames='\n    '.join(frames),
-                    boxes='\n    '.join(boxes),
-                    title=trans.get_translation("title"),
-                    **meta)
+            return data.format(
+                annotation=annotation,
+                frames="\n    ".join(frames),
+                boxes="\n    ".join(boxes),
+                title=trans.get_translation("title"),
+                **meta,
+            )
         except KeyError as e:
-            raise errors.ConfigurationError(("The key %s is missing in the "
-                "configuration.") % e.args[0], meta['path'])
+            raise errors.ConfigurationError(
+                ("The key %s is missing in the " "configuration.") % e.args[0],
+                meta["path"],
+            )
 
     def set_meta_data(self, meta):
         """Overwrite parent settr to re-generate template generation."""
@@ -150,6 +173,7 @@ class HtmlConverter(OutputGenerator):
     def convert(self, files, **kwargs):
         """See super class documentation."""
         from ..converter import Pandoc
+
         cache, files = Pandoc.get_cache(files)
         try:
             for file_name in files:
@@ -165,8 +189,9 @@ class HtmlConverter(OutputGenerator):
     def __handle_error(file_name, err):
         # set path for error
         if not err.path:
-            err.path = os.path.abspath(file_name).replace(os.getcwd(), '').\
-                    lstrip(os.sep)
+            err.path = (
+                os.path.abspath(file_name).replace(os.getcwd(), "").lstrip(os.sep)
+            )
         if not isinstance(err, errors.MathError):
             raise err
         # recover line and pos of formula
@@ -174,9 +199,9 @@ class HtmlConverter(OutputGenerator):
         line, pos = list(eqns.keys())[err.formula_count - 1]
         err.line = line
         err.pos = pos
-        raise err from None # no TB here
+        raise err from None  # no TB here
 
-    #pylint: disable=too-many-locals
+    # pylint: disable=too-many-locals
     def __convert_document(self, path, file_cache):
         """Convert a document by a given path. It takes a converter which takes
         actual care of the underlying format. The filecache caches the list of
@@ -187,42 +212,61 @@ class HtmlConverter(OutputGenerator):
         # only convert if output file is newer than input file
         if not self.needs_update(path):
             return
-        with open(path, 'r', encoding='utf-8') as file:
+        with open(path, "r", encoding="utf-8") as file:
             document = file.read()
         if not document:
-            return # skip empty documents
+            return  # skip empty documents
         if OutputGenerator.IS_CHAPTER.search(os.path.basename(path)):
             try:
                 nav_start, nav_end = self.generate_page_navigation(
-                    path, file_cache,
+                    path,
+                    file_cache,
                     mparser.extract_page_numbers_from_par(
-                        mparser.file2paragraphs(document))
-                    )
+                        mparser.file2paragraphs(document)
+                    ),
+                )
             except errors.FormattingError as e:
                 e.path = path
                 raise e from None
-            document = '{}\n\n{}\n\n{}\n'.format(nav_start, document, nav_end)
+            document = "{}\n\n{}\n\n{}\n".format(nav_start, document, nav_end)
         json_ast = contentfilter.load_pandoc_ast(document)
         self.__apply_filters(json_ast, path)
         dirname, filename = os.path.split(path)
-        outputf = os.path.splitext(filename)[0] + '.' + self.FILE_EXTENSION
-        pandoc_args = ['-s', '--template=%s' % self.template_path]
+        outputf = os.path.splitext(filename)[0] + "." + self.FILE_EXTENSION
+        pandoc_args = ["-s", "--template=%s" % self.template_path]
         # set title
         title = contentfilter.get_title(json_ast)
-        if title: # if not None
-            pandoc_args += ['-V', 'pagetitle:' + title, '-V', 'title:' + title]
+        if title:  # if not None
+            pandoc_args += ["-V", "pagetitle:" + title, "-V", "title:" + title]
         # instruct pandoc to enumerate headings
         try:
-            pandoc_args += ['--number-sections', '--number-offset',
-                str(datastructures.extract_chapter_number(path) - 1)]
+            pandoc_args += [
+                "--number-sections",
+                "--number-offset",
+                str(datastructures.extract_chapter_number(path) - 1),
+            ]
         except errors.StructuralError:
-            pass # no enumeration of headings if not chapter
+            pass  # no enumeration of headings if not chapter
         # for 'blind' see __apply_filters, doesn't need a Pandoc argument
         if self.get_profile() is ConversionProfile.VisuallyImpairedDefault:
-            pandoc_args.append('--mathjax')
-        execute(['pandoc'] + pandoc_args + ['-t', self.PANDOC_FORMAT_NAME,
-            '-f', 'json', '+RTS', '-K25000000', '-RTS', # increase stack size
-            '-o', outputf], stdin=json.dumps(json_ast), cwd=dirname)
+            pandoc_args.append("--mathjax")
+        execute(
+            ["pandoc"]
+            + pandoc_args
+            + [
+                "-t",
+                self.PANDOC_FORMAT_NAME,
+                "-f",
+                "json",
+                "+RTS",
+                "-K25000000",
+                "-RTS",  # increase stack size
+                "-o",
+                outputf,
+            ],
+            stdin=json.dumps(json_ast),
+            cwd=dirname,
+        )
 
     def __apply_filters(self, json_ast, file_path):
         """Process MAGSBS-specific markdown extensions using Pandoc filters.
@@ -233,15 +277,20 @@ class HtmlConverter(OutputGenerator):
             fmt = self.PANDOC_FORMAT_NAME
             for filter_ in self.CONTENT_FILTERS:
                 json_ast = pandocfilters.walk(json_ast, filter_, fmt, [])
-        except KeyError as e: # API clash(?)
-            raise errors.StructuralError(("Incompatible Pandoc API found, while "
-                "applying filter %s (ABI clash?).\nKeyError: %s") % \
-                        (filter.__name__, str(e)), file_path)
+        except KeyError as e:  # API clash(?)
+            raise errors.StructuralError(
+                (
+                    "Incompatible Pandoc API found, while "
+                    "applying filter %s (ABI clash?).\nKeyError: %s"
+                )
+                % (filter.__name__, str(e)),
+                file_path,
+            )
         # use GleeTeX if configured
         if self.get_profile() is ConversionProfile.Blind:
             try:
                 # this alters the Pandoc document AST -- no return required
-                contentfilter.convert_formulas(file_path, 'bilder', json_ast)
+                contentfilter.convert_formulas(file_path, "bilder", json_ast)
             except errors.MathError as err:
                 HtmlConverter.__handle_error(file_path, err)
 
@@ -263,34 +312,41 @@ class HtmlConverter(OutputGenerator):
         trans.set_language(conf[config.MetaInfo.Language])
         relative_path = os.sep.join(file_path.rsplit(os.sep)[-2:])
         previous, nxt = file_cache.get_neighbours_for(relative_path)
-        make_path = lambda path: '../{}/{}'.format(path[0], path[1].replace('.md',
-            '.' + self.FILE_EXTENSION))
+        make_path = lambda path: "../{}/{}".format(
+            path[0], path[1].replace(".md", "." + self.FILE_EXTENSION)
+        )
         if previous:
-            previous = '[{}]({})'.format(trans.get_translation('previous').title(),
-                    make_path(previous))
+            previous = "[{}]({})".format(
+                trans.get_translation("previous").title(), make_path(previous)
+            )
         if nxt:
-            nxt = '[{}]({})'.format(trans.get_translation('next').title(),
-                    make_path(nxt))
+            nxt = "[{}]({})".format(
+                trans.get_translation("next").title(), make_path(nxt)
+            )
         navbar = []
         # take each pnumgapth element
-        page_numbers = [pnum for pnum in page_numbers
-            if (pnum.number % conf[config.MetaInfo.PageNumberingGap]) == 0]
+        page_numbers = [
+            pnum
+            for pnum in page_numbers
+            if (pnum.number % conf[config.MetaInfo.PageNumberingGap]) == 0
+        ]
         if page_numbers:
-            navbar.append(trans.get_translation('pages').title() + ': ')
-            navbar.extend('[[{0}]](#p{0}), '.format(num) for num in page_numbers)
-            navbar[-1] = navbar[-1][:-2] # strip ", " from last chunk
-        navbar = ''.join(navbar)
-        chapternav = '[{}](../inhalt.{})'.format(trans.get_translation(
-                'table of contents').title(), self.FILE_EXTENSION)
+            navbar.append(trans.get_translation("pages").title() + ": ")
+            navbar.extend("[[{0}]](#p{0}), ".format(num) for num in page_numbers)
+            navbar[-1] = navbar[-1][:-2]  # strip ", " from last chunk
+        navbar = "".join(navbar)
+        chapternav = "[{}](../inhalt.{})".format(
+            trans.get_translation("table of contents").title(), self.FILE_EXTENSION
+        )
 
         if previous:
-            chapternav = previous + '  ' + chapternav
+            chapternav = previous + "  " + chapternav
         if nxt:
             chapternav += "  " + nxt
         # navigation at start of page
-        nav_start = '{0}\n\n{1}\n\n* * * *\n\n\n'.format(chapternav, navbar)
+        nav_start = "{0}\n\n{1}\n\n* * * *\n\n\n".format(chapternav, navbar)
         # navigation bar at end of page
-        nav_end = '\n\n* * * *\n\n{0}\n\n{1}\n'.format(navbar, chapternav)
+        nav_end = "\n\n* * * *\n\n{0}\n\n{1}\n".format(navbar, chapternav)
         return (nav_start, nav_end)
 
     def cleanup(self):
@@ -299,7 +355,7 @@ class HtmlConverter(OutputGenerator):
     def needs_update(self, path):
         # if file exists and input is newer than output, needs to be converted
         # again
-        output = os.path.splitext(path)[0] + '.' + self.FILE_EXTENSION
+        output = os.path.splitext(path)[0] + "." + self.FILE_EXTENSION
         if not os.path.exists(output):
             return True
         # True if source file is newer:

--- a/MAGSBS/quality_assurance/all_formats.py
+++ b/MAGSBS/quality_assurance/all_formats.py
@@ -5,24 +5,35 @@ from xml.etree import ElementTree as ET
 from .. import config, common
 from .meta import MistakeType, Mistake, OnelinerMistake
 
+
 class ConfigurationValuesAreAllSet(Mistake):
     """Check whether all configuration options have been set."""
+
     mistake_type = MistakeType.configuration
+
     def __init__(self):
         super().__init__()
-        self.set_file_types(['dcxml'])
+        self.set_file_types(["dcxml"])
 
     def worker(self, *args):
         tree = ET.parse(args[0])
         root = tree.getroot()
+
         def get_tag(node):
-            return node.tag[node.tag.find('}') + 1 :]
+            return node.tag[node.tag.find("}") + 1 :]
+
         for node in root.getchildren():
-            if not node.text or 'unknown' in node.text.lower():
-                return self.error(_("Error in the lecture configuration: "
+            if not node.text or "unknown" in node.text.lower():
+                return self.error(
+                    _(
+                        "Error in the lecture configuration: "
                         "the value {} is unset, thefefore the meta data in the "
-                        "HTML files cannot be generated.").format(get_tag(node)),
-                    config.get_lnum_of_tag(args[0], node.tag), args[0])
+                        "HTML files cannot be generated."
+                    ).format(get_tag(node)),
+                    config.get_lnum_of_tag(args[0], node.tag),
+                    args[0],
+                )
+
 
 class BrokenUmlautsFromPDFFiles(OnelinerMistake):
     """When copying texts over from PDF's, the umlauts often are unreadable.
@@ -30,34 +41,58 @@ class BrokenUmlautsFromPDFFiles(OnelinerMistake):
     as their respective Latin vowel with a special formatting directive to lift
     an accent or whatever above it. Flag those umlauts, if the editor didn't
     convert them yet to proper umlauts."""
+
     def __init__(self):
         super().__init__()
         self.set_file_types(["md"])
         # save the malicious sequences as UTF-8 byte arrays
-        self.garbled = [b'\xc2\xb4\xc4\xb1', b'\xc2\xa8\xc4\xb1',
-                    b'\xc2\xb8c'] + \
-                [b'\xc2\xa8' + l  for l in [b'a', b'o', b'u', b's']] + \
-                [b'\xc2\xa8 ' + l  for l in [b'a', b'o', b'u', b's']]
-        self.garbled = [x.decode('utf-8') for x in self.garbled]
+        self.garbled = (
+            [b"\xc2\xb4\xc4\xb1", b"\xc2\xa8\xc4\xb1", b"\xc2\xb8c"]
+            + [b"\xc2\xa8" + l for l in [b"a", b"o", b"u", b"s"]]
+            + [b"\xc2\xa8 " + l for l in [b"a", b"o", b"u", b"s"]]
+        )
+        self.garbled = [x.decode("utf-8") for x in self.garbled]
 
     def check(self, num, line):
         for seq in self.garbled:
             if seq in line:
-                return super().error(_("Incorrectly formatted umlauts have "
-                    "been found. This usually happens when copying texts from "
-                    "PDFs. This makes text nearly impossible to read."), num)
+                return super().error(
+                    _(
+                        "Incorrectly formatted umlauts have "
+                        "been found. This usually happens when copying texts from "
+                        "PDFs. This makes text nearly impossible to read."
+                    ),
+                    num,
+                )
+
 
 class OnlyCorrectDirectoriesFound(Mistake):
     mistake_type = MistakeType.lecture_root
+
     def worker(self, *args):
         root = args[0]
         for file in os.listdir(root):
-            if any(file.startswith(x) for x in ('bilder', 'tabellen', 'inhalt', 'titel',
-                    'glossar', 'index', 'kurz' 'taktil', 'copyright',
-                    '.lecture_meta')):
+            if any(
+                file.startswith(x)
+                for x in (
+                    "bilder",
+                    "tabellen",
+                    "inhalt",
+                    "titel",
+                    "glossar",
+                    "index",
+                    "kurz" "taktil",
+                    "copyright",
+                    ".lecture_meta",
+                )
+            ):
                 continue
             if not common.is_valid_file(file):
-                return self.error(_("The naming of the file or directory \"{}\""
-                    " is incorrect and does not follow the naming conventions. "
-                    "This leads to an incorrect usage of the file.").format(file), path=root)
-
+                return self.error(
+                    _(
+                        'The naming of the file or directory "{}"'
+                        " is incorrect and does not follow the naming conventions. "
+                        "This leads to an incorrect usage of the file."
+                    ).format(file),
+                    path=root,
+                )

--- a/MAGSBS/quality_assurance/latex.py
+++ b/MAGSBS/quality_assurance/latex.py
@@ -6,28 +6,37 @@ embedded there as well."""
 import re
 from .meta import FormulaMistake, OnelinerMistake, Mistake, MistakeType
 
+
 class CasesSqueezedOnOneLine(FormulaMistake):
     r"""\begin{cases} ... lots of stuff \end{cases} is hard to read. There
     should be actual line breaks after \\\\."""
+
     def __init__(self):
         super().__init__()
         self.set_file_types(["md", "tex"])
 
     def worker(self, *formulas):
         for pos, formula in formulas[0].items():
-            if '\n' in formula:
+            if "\n" in formula:
                 continue
-            if r'\begin{cases}' in formula and r'\end{cases}' in formula:
-                return self.error(_("The LaTeX environment \"cases\" should "
+            if r"\begin{cases}" in formula and r"\end{cases}" in formula:
+                return self.error(
+                    _(
+                        'The LaTeX environment "cases" should '
                         "contain line breaks at suitable places to increase "
-                        "readibility."), lnum=pos[0], pos=pos[1])
-
+                        "readibility."
+                    ),
+                    lnum=pos[0],
+                    pos=pos[1],
+                )
 
 
 class LaTeXMatricesShouldBeConstructeedUsingPmatrix(FormulaMistake):
     """There are various ways to make matrices hard to read. Spot and report
     them."""
+
     PATTERN = re.compile(r".*(\\left|\\big|\\Big)(\(|\{).*?begin{(array|matrix)")
+
     def __init__(self):
         super().__init__()
         self.set_file_types(["md", "tex"])
@@ -35,10 +44,16 @@ class LaTeXMatricesShouldBeConstructeedUsingPmatrix(FormulaMistake):
     def worker(self, *args):
         for (line, pos), formula in args[0].items():
             if self.PATTERN.search(formula):
-                return self.error(_("To increase readibility, matrices should "
-                    "not be constructed using manual formatting commands, but "
-                    "using \"\\begin{pmatrix}...\". This is also shorter."),
-                    lnum=line, pos=pos)
+                return self.error(
+                    _(
+                        "To increase readibility, matrices should "
+                        "not be constructed using manual formatting commands, but "
+                        'using "\\begin{pmatrix}...". This is also shorter.'
+                    ),
+                    lnum=line,
+                    pos=pos,
+                )
+
 
 class LaTeXMatricesShouldHaveLineBreaks(FormulaMistake):
     def __init__(self):
@@ -49,16 +64,20 @@ class LaTeXMatricesShouldHaveLineBreaks(FormulaMistake):
     def worker(self, *args):
         for (line, pos), formula in args[0].items():
             if self.pattern.search(formula):
-                return self.error(_("Each line of a matrix or table should "
-                        "be written on one line, using a hard line break."),
-                    lnum=line, pos=pos)
+                return self.error(
+                    _(
+                        "Each line of a matrix or table should "
+                        "be written on one line, using a hard line break."
+                    ),
+                    lnum=line,
+                    pos=pos,
+                )
 
 
 class LaTeXUmlautsUsed(FormulaMistake):
     r"""Some people tend to use \"a etc. to display umlauts. That is hard to
     read. Currently, only German umlauts are  considered."""
-    UMLAUTS = ['\\"a', '{"a}', '\\"u', '{"u}', '\\"o', '"o', '\\3',
-            '{"s}', '\\"s']
+    UMLAUTS = ['\\"a', '{"a}', '\\"u', '{"u}', '\\"o', '"o', "\\3", '{"s}', '\\"s']
 
     def __init__(self):
         super().__init__()
@@ -68,79 +87,110 @@ class LaTeXUmlautsUsed(FormulaMistake):
         for pos, formula in formulas.items():
             formula = formula.lower()
             if any(t in formula for t in self.UMLAUTS):
-                return super().error(_("Instead of using an actual umlaut, a "
-                    "LaTeX control sequence was used. This is hard to read and "
-                    "not required with this program."), lnum=pos[0], pos=pos[1])
+                return super().error(
+                    _(
+                        "Instead of using an actual umlaut, a "
+                        "LaTeX control sequence was used. This is hard to read and "
+                        "not required with this program."
+                    ),
+                    lnum=pos[0],
+                    pos=pos[1],
+                )
 
 
 class DisplayMathShouldNotBeUsedWithinAParagraph(OnelinerMistake):
     """DisplayMath should not be used within a paragraph. That is against the
     idea of displaymath and will additionally result in incorrect
     formatting."""
-    PATTERN = re.compile(r'^.*?(\w+\s*\$\$.*\$\$|\$\$.*?\$\$\s*\w+).*')
+
+    PATTERN = re.compile(r"^.*?(\w+\s*\$\$.*\$\$|\$\$.*?\$\$\s*\w+).*")
+
     def check(self, num, line):
         if line:
             matched = self.PATTERN.search(line)
             if matched:
-                return self.error(_("Formulas within a paragraph surrounded by "
+                return self.error(
+                    _(
+                        "Formulas within a paragraph surrounded by "
                         "text have to be set with single dollars, because the "
                         "formulas don't integrate into the line otherwise. $$ "
                         "(displaymath) should be used in formulas standing on "
-                        "their own in a paragraph."), num, pos=matched.span()[1])
+                        "their own in a paragraph."
+                    ),
+                    num,
+                    pos=matched.span()[1],
+                )
+
 
 class SpacingInFormulaShouldBeDoneWithQuad(FormulaMistake):
     r"""Some people tend to use `\ \ \ \ ...` to format a bigger space within
     an equation. This is hard to read and hence \quad should be used."""
+
     def worker(self, *args):
         for (line, pos), formula in args[0].items():
-            if r'\ \ \ \ ' in formula:
-                return self.error(_("Empty space in formulas should be set "
+            if r"\ \ \ \ " in formula:
+                return self.error(
+                    _(
+                        "Empty space in formulas should be set "
                         "with \\quad or \\qquad, because they are otherwise "
-                        "hard to read with speech synthesis."),
-                    lnum=line, pos=pos)
+                        "hard to read with speech synthesis."
+                    ),
+                    lnum=line,
+                    pos=pos,
+                )
+
 
 class UseProperCommandsForMathOperatorsAndFunctions(FormulaMistake):
     r"""\min, \max, ... should be marked up correctly."""
-    OPSANDFUNCS = tuple(re.compile(r'\b%s\b' % op)
-            for op in ('sin', 'cos', 'max', 'min', 'tan'))
+    OPSANDFUNCS = tuple(
+        re.compile(r"\b%s\b" % op) for op in ("sin", "cos", "max", "min", "tan")
+    )
 
     def __init__(self):
         super().__init__()
-        self.set_file_types(['md', 'tex'])
+        self.set_file_types(["md", "tex"])
 
     def worker(self, *args):
-        has_backslash = lambda text, idx: (text[idx - 1] == '\\' if idx > 0
-                else False)
+        has_backslash = lambda text, idx: (text[idx - 1] == "\\" if idx > 0 else False)
         for (line, pos), formula in args[0].items():
             for mathop in self.OPSANDFUNCS:
                 match = mathop.search(formula)
                 if not match:
                     continue
                 if not has_backslash(formula, match.span()[0]):
-                    return self.error(_("'{0}' should be generally set using "
-                        "the appropriate LaTeX command, namely using \\{0}. "
-                        "This way it will be properly formatted in the output "
-                        "and easily readable by screen readers.").format(
-                        mathop.pattern.replace('\\b', '')), lnum=line, pos=pos)
+                    return self.error(
+                        _(
+                            "'{0}' should be generally set using "
+                            "the appropriate LaTeX command, namely using \\{0}. "
+                            "This way it will be properly formatted in the output "
+                            "and easily readable by screen readers."
+                        ).format(mathop.pattern.replace("\\b", "")),
+                        lnum=line,
+                        pos=pos,
+                    )
 
 
 class FreeStandingFormulasShouldBeDisplaymath(Mistake):
     """This checker checks whether some formula was set with inline maths on a
     paragraph, but since it's a free standing one, should be rather formatted
     as display maths."""
+
     mistake_tyke = MistakeType.full_file
-    START = re.compile(r'^\s*\$(?!\$).+')
-    END = re.compile(r'.+\$(?!\$)\s*$')
+    START = re.compile(r"^\s*\$(?!\$).+")
+    END = re.compile(r".+\$(?!\$)\s*$")
 
     def worker(self, *args):
         for start_line, para in args[0].items():
             if self.START.search(para[0]) and self.END.search(para[-1]):
                 # count dollars to be sure that it's just one math env
-                if sum(l.count('$') for l in para) == 2:
-                    return self.error(_("A formula, occurring on a paragraph "
+                if sum(l.count("$") for l in para) == 2:
+                    return self.error(
+                        _(
+                            "A formula, occurring on a paragraph "
                             "on its own, has been set as an embedded formula "
                             "using single dollars. Instead double dollar signs "
                             "around the formula should be used, so that the "
-                            "formula is not squeezed to the line height."),
-                        lnum=start_line)
-
+                            "formula is not squeezed to the line height."
+                        ),
+                        lnum=start_line,
+                    )

--- a/MAGSBS/quality_assurance/linkchecker.py
+++ b/MAGSBS/quality_assurance/linkchecker.py
@@ -44,7 +44,7 @@ def format_extensions_list(extensions):
         raise ValueError(_("Expected a file extension, got nothing"))
     if len(extensions) == 1:
         return ".{}".format(extensions[0])
-    return _(".{} or .{}").format(', .'.join(extensions[:-1]), extensions[-1])
+    return _(".{} or .{}").format(", .".join(extensions[:-1]), extensions[-1])
 
 
 def get_list_of_md_files(file_tree):
@@ -80,6 +80,7 @@ class LinkChecker:
     where links are pointing. All errors are saved in the public attribute
     self.errors. Parsed headings are taken from the mistkerl to avoid opening
     same files repeatedly. """
+
     def __init__(self, reference_list, headings):
         self.errors = []  # generated errors
         self.reference_list = reference_list
@@ -100,8 +101,10 @@ class LinkChecker:
             if reference.type == Reference.Type.EXPLICIT:
                 # identifier should exist for it
                 self.find_link_for_identifier(reference)
-            if not reference.is_footnote and reference.type \
-                    in {Reference.Type.EXPLICIT, Reference.Type.INLINE}:
+            if not reference.is_footnote and reference.type in {
+                Reference.Type.EXPLICIT,
+                Reference.Type.INLINE,
+            }:
                 self.check_target_availability(reference)
 
     def find_label_for_link(self, reference):
@@ -112,15 +115,21 @@ class LinkChecker:
         Note: Identifiers are not case sensitive. """
         ref_id = reference.id.lower()
         for tested_ref in self.reference_list:
-            if tested_ref.type == Reference.Type.EXPLICIT \
-                    and tested_ref.id.lower() == ref_id and \
-                    tested_ref.file_path == reference.file_path:
+            if (
+                tested_ref.type == Reference.Type.EXPLICIT
+                and tested_ref.id.lower() == ref_id
+                and tested_ref.file_path == reference.file_path
+            ):
                 return  # it is ok, identifier has been found
-        e = ErrorMessage(_("An explicit reference with identifier \"{0}\" does"
-                           " not exist. Please write an explicit reference in"
-                           " a form \"[{0}]: link\" to the markdown file.")
-                         .format(ref_id), reference.line_number,
-                         reference.file_path)
+        e = ErrorMessage(
+            _(
+                'An explicit reference with identifier "{0}" does'
+                " not exist. Please write an explicit reference in"
+                ' a form "[{0}]: link" to the markdown file.'
+            ).format(ref_id),
+            reference.line_number,
+            reference.file_path,
+        )
         e.pos_on_line = reference.pos_on_line
         self.errors.append(e)
 
@@ -131,8 +140,9 @@ class LinkChecker:
         Note: If the references with same identifiers are completely the same
         then they are not reported. """
         # check only explicit references
-        list_of_labels = [ref for ref in self.reference_list if
-                          ref.type == Reference.Type.EXPLICIT]
+        list_of_labels = [
+            ref for ref in self.reference_list if ref.type == Reference.Type.EXPLICIT
+        ]
         seen = set()  # set of link_texts (labels) that were already checked
         for ref in list_of_labels:
             if ref.id.lower() not in seen:
@@ -140,15 +150,19 @@ class LinkChecker:
                 seen.add(ref_id)  # add as seen
                 for tested_ref in list_of_labels:
                     # refs have to be in same file and have same identifier
-                    if tested_ref.file_path == ref.file_path \
-                            and tested_ref.id.lower() == ref_id \
-                            and ref != tested_ref:  # ignore same dicts
+                    if (
+                        tested_ref.file_path == ref.file_path
+                        and tested_ref.id.lower() == ref_id
+                        and ref != tested_ref
+                    ):  # ignore same dicts
                         e = ErrorMessage(
-                            _("Identifier \"{}\" for reference is duplicated "
-                              "on lines {} and {}.")
-                            .format(ref_id, ref.line_number,
-                                    tested_ref.line_number),
-                            ref.line_number, ref.file_path)
+                            _(
+                                'Identifier "{}" for reference is duplicated '
+                                "on lines {} and {}."
+                            ).format(ref_id, ref.line_number, tested_ref.line_number),
+                            ref.line_number,
+                            ref.file_path,
+                        )
                         e.pos_on_line = ref.pos_on_line
                         self.errors.append(e)
 
@@ -159,16 +173,23 @@ class LinkChecker:
         Note: Identifiers are not case sensitive. """
         ref_id = reference.id.lower()
         for tested_ref in self.reference_list:
-            if tested_ref.type == Reference.Type.IMPLICIT \
-                    and tested_ref.id.lower() == ref_id and \
-                    tested_ref.file_path == reference.file_path:
+            if (
+                tested_ref.type == Reference.Type.IMPLICIT
+                and tested_ref.id.lower() == ref_id
+                and tested_ref.file_path == reference.file_path
+            ):
                 return  # it is ok, same identifier has been found
-        e = ErrorMessage(_("Implicit reference with the identifier "
-                            "\"{0}\" does not exist. Please write a "
-                            "reference in a form [{0}] in the markdown "
-                            "file or remove the anchor [{0}]:"
-                            " {1}.").format(ref_id, reference.link),
-                          reference.line_number, reference.file_path)
+        e = ErrorMessage(
+            _(
+                "Implicit reference with the identifier "
+                '"{0}" does not exist. Please write a '
+                "reference in a form [{0}] in the markdown "
+                "file or remove the anchor [{0}]:"
+                " {1}."
+            ).format(ref_id, reference.link),
+            reference.line_number,
+            reference.file_path,
+        )
         e.pos_on_line = reference.pos_on_line
         self.errors.append(e)
 
@@ -180,8 +201,11 @@ class LinkChecker:
         parsed_url = urlparse(reference.link)
         # True if it is a file in a file structure; excepted strings removes
         # false positives
-        is_file = not parsed_url.netloc and not parsed_url.scheme and \
-            not self.starts_with_excepted_string(parsed_url.path)
+        is_file = (
+            not parsed_url.netloc
+            and not parsed_url.scheme
+            and not self.starts_with_excepted_string(parsed_url.path)
+        )
         inspect_fragment = False  # specify if anchor should be inspected
         if parsed_url.path and is_file:  # if something is in path
             # prepare main paths
@@ -194,12 +218,14 @@ class LinkChecker:
                 if self.is_correct_extension(parsed_url.path, reference):
                     # checking .md existence and anchors only for non-images
                     if not reference.is_image:
-                        if self.target_md_file_exists(parsed_url.path,
-                                                      reference, file_path):
+                        if self.target_md_file_exists(
+                            parsed_url.path, reference, file_path
+                        ):
                             inspect_fragment = True
 
-        if (parsed_url.fragment and inspect_fragment) or \
-                (not parsed_url.path and is_file):
+        if (parsed_url.fragment and inspect_fragment) or (
+            not parsed_url.path and is_file
+        ):
             # check fragment only in situation when file exists .md file within
             # project and when path is empty (it is the same file)
             self.target_anchor_exists(parsed_url, reference)
@@ -220,24 +246,32 @@ class LinkChecker:
         should exist and correspond to the allowed ones. Method returns True,
         if the file in the given path has correct extension, False otherwise.
         """
-        extensions = IMAGE_EXTENSIONS if reference.is_image \
-            else WEB_EXTENSIONS  # choose the correct extension
+        extensions = (
+            IMAGE_EXTENSIONS if reference.is_image else WEB_EXTENSIONS
+        )  # choose the correct extension
 
         if path.rfind(".") < 0:  # no extension
             e = ErrorMessage(
-                _("Link path \"{}\" has no extension, but it should be {}.")
-                .format(path, format_extensions_list(extensions)),
-                reference.line_number, reference.file_path)
+                _('Link path "{}" has no extension, but it should be {}.').format(
+                    path, format_extensions_list(extensions)
+                ),
+                reference.line_number,
+                reference.file_path,
+            )
 
             self.errors.append(e)
             return False
         # search fo last comma and extension is what follows it
-        elif path[path.rfind(".") + 1:].lower() not in extensions:
+        elif path[path.rfind(".") + 1 :].lower() not in extensions:
             e = ErrorMessage(
-                _("Link path \"{}\" has extension .{}, but it should be {}.")
-                .format(path, path[path.rfind(".") + 1:],
-                        format_extensions_list(extensions)),
-                reference.line_number, reference.file_path)
+                _('Link path "{}" has extension .{}, but it should be {}.').format(
+                    path,
+                    path[path.rfind(".") + 1 :],
+                    format_extensions_list(extensions),
+                ),
+                reference.line_number,
+                reference.file_path,
+            )
             e.pos_on_line = reference.pos_on_line
             self.errors.append(e)
             return False
@@ -247,21 +281,24 @@ class LinkChecker:
         """Checks whether the target file exists. """
         if not os.path.exists(file_path):
             e = ErrorMessage(
-                    _("The file \"{}\" given by the reference \"{}\" does not"
-                      " exist.").format(parsed_path, reference.id),
-                    reference.line_number, reference.file_path)
+                _(
+                    'The file "{}" given by the reference "{}" does not' " exist."
+                ).format(parsed_path, reference.id),
+                reference.line_number,
+                reference.file_path,
+            )
             e.pos_on_line = reference.pos_on_line
             self.errors.append(e)
 
     def target_md_file_exists(self, parsed_path, reference, file_path):
         """Within the lecture structure, hypertext files are generated from
         .md files. Therefore, source .md file existence should be checked. """
-        file_path_md = "{}.{}".format(os.path.splitext(file_path)[0], 'md')
+        file_path_md = "{}.{}".format(os.path.splitext(file_path)[0], "md")
         if not os.path.exists(file_path_md):
-            error_message = _("The source .md file for hypertext file \"{}\" "
-                              "does not exist.").format(parsed_path)
-            e = ErrorMessage(error_message, reference.line_number,
-                             reference.file_path)
+            error_message = _(
+                'The source .md file for hypertext file "{}" ' "does not exist."
+            ).format(parsed_path)
+            e = ErrorMessage(error_message, reference.line_number, reference.file_path)
             e.pos_on_line = reference.pos_on_line
             self.errors.append(e)
             return False
@@ -283,18 +320,25 @@ class LinkChecker:
                 return  # anchor was found
 
         if not parsed_url.path:
-            e = ErrorMessage(_("A link is referencing the anchor \"#{}\" "
-                               "which does not exist.").format(
-                    parsed_url.fragment, path),
-                    reference.line_number, reference.file_path)
+            e = ErrorMessage(
+                _(
+                    'A link is referencing the anchor "#{}" ' "which does not exist."
+                ).format(parsed_url.fragment, path),
+                reference.line_number,
+                reference.file_path,
+            )
             e.pos_on_line = reference.pos_on_line
             self.errors.append(e)
 
         else:
-            e = ErrorMessage(_("A link references the anchor \"#{}\" which "
-                               "does not exist in the file {}.").format(
-                    parsed_url.fragment, parsed_url.path),
-                    reference.line_number, reference.file_path)
+            e = ErrorMessage(
+                _(
+                    'A link references the anchor "#{}" which '
+                    "does not exist in the file {}."
+                ).format(parsed_url.fragment, parsed_url.path),
+                reference.line_number,
+                reference.file_path,
+            )
             e.pos_on_line = reference.pos_on_line
             self.errors.append(e)
 
@@ -305,9 +349,10 @@ class LinkChecker:
         if not path:
             return reference.file_path
 
-        full_path = os.path.realpath(os.path.join(os.path.dirname(
-            reference.file_path), path))
-        return "{}.{}".format(os.path.splitext(full_path)[0], 'md')
+        full_path = os.path.realpath(
+            os.path.join(os.path.dirname(reference.file_path), path)
+        )
+        return "{}.{}".format(os.path.splitext(full_path)[0], "md")
 
     def load_headings(self, path):
         """This method loads headings into the __cached_headings attribute
@@ -316,8 +361,7 @@ class LinkChecker:
         """
         with open(path, encoding="utf-8") as file:
             paragraphs = mparser.file2paragraphs(file.read())
-        self.__cached_headings[path] = mparser.extract_headings_from_par(
-            paragraphs)
+        self.__cached_headings[path] = mparser.extract_headings_from_par(paragraphs)
 
     def load_ids(self, path):
         """This method loads ids of div and span elements into
@@ -325,5 +369,6 @@ class LinkChecker:
         loading same files repeatedly if links are pointing to the same files.
         """
         with open(path, encoding="utf-8") as file:
-            self.__cashed_html_ids[path] = \
-                mparser.get_html_elements_identifiers(file.read())
+            self.__cashed_html_ids[path] = mparser.get_html_elements_identifiers(
+                file.read()
+            )

--- a/MAGSBS/quality_assurance/markdown.py
+++ b/MAGSBS/quality_assurance/markdown.py
@@ -2,22 +2,29 @@
 # details.
 #
 # (c) 2015-2018 Sebastian Humenda <shumenda |at| gmx |dot| de>
-#pylint: disable=line-too-long,arguments-differ,too-few-public-methods,no-self-use
+# pylint: disable=line-too-long,arguments-differ,too-few-public-methods,no-self-use
 """All checkers for MarkDown files belong here."""
 
 import os
 import re
 from .meta import Mistake, MistakeType, OnelinerMistake
 from .. import config, common
+
 MetaInfo = config.MetaInfo
+
 
 class PageNumberIsParagraph(Mistake):
     """Check whether all page numbers are on a paragraph on their own."""
+
     def __init__(self):
         super().__init__()
-        self._error_text = _("Each line number has to have an empty line "
-                    "before and after it, that is, on a paragraph of its own.")
-        self.pattern = re.compile(r'^\|\|\s*' + config.PAGENUMBERING_PATTERN.pattern, re.VERBOSE)
+        self._error_text = _(
+            "Each line number has to have an empty line "
+            "before and after it, that is, on a paragraph of its own."
+        )
+        self.pattern = re.compile(
+            r"^\|\|\s*" + config.PAGENUMBERING_PATTERN.pattern, re.VERBOSE
+        )
 
     def error(self, lnum):
         return super().error(self._error_text, lnum)
@@ -25,7 +32,7 @@ class PageNumberIsParagraph(Mistake):
     def worker(self, *args):
         for start_line, paragraph in args[0].items():
             if len(paragraph) == 1:
-                continue # that's either a correct one or not interesting
+                continue  # that's either a correct one or not interesting
             for num, line in enumerate(paragraph):
                 # more than one line and a page number, bug
                 result = self.pattern.search(line.lower())
@@ -35,20 +42,26 @@ class PageNumberIsParagraph(Mistake):
 
 class LevelOneHeading(Mistake):
     """Parse the directory and raise errors if more than one level-1-heading was encountered."""
+
     mistake_type = MistakeType.headings_dir
+
     def worker(self, *args):
         found_h1 = False
         for path, headings in args[0].items():
-            if os.path.basename(path).lower() == 'bilder.md':
-                continue # do not count h1's in bilder.md
+            if os.path.basename(path).lower() == "bilder.md":
+                continue  # do not count h1's in bilder.md
 
             for heading in headings:
                 if heading.get_level() == 1:
                     if found_h1:
-                        return self.error(_("There is more than one heading of "
+                        return self.error(
+                            _(
+                                "There is more than one heading of "
                                 "level one, which is not allowed. For instance,"
                                 " a slide set or a chapter has only one heading"
-                                " of level 1."))
+                                " of level 1."
+                            )
+                        )
                     else:
                         found_h1 = True
 
@@ -57,16 +70,20 @@ class ItemizeIsParagraph(Mistake):
     """Go through each paragraph and check whether a line is a valid item for
     an itemize environment. If Ignore first and last line of course. If it is,
     check whether first and last line are valid, else return error."""
+
     mistake_type = MistakeType.full_file
 
     def __init__(self):
         super().__init__()
-        self._itemize_pattern = re.compile(r'''^\s*  # tolerate any whitespace in front
+        self._itemize_pattern = re.compile(
+            r"""^\s*  # tolerate any whitespace in front
             (-|\+|\* # any itemize character
              |\(?(\d+|[iIvVlLxXcC]+)\) # understand any arabic/roman number enclosed or terminated by parenthesis
              |(\d+|[iIvVlLxXcC]+)\.)
             \s+ # at least one space required after item
-            ''', re.VERBOSE)
+            """,
+            re.VERBOSE,
+        )
 
     def worker(self, *args):
         """Only mark this as an error, when more than two itemize signs have
@@ -82,14 +99,16 @@ class ItemizeIsParagraph(Mistake):
             item_encountered = False
             for lnum, line in enumerate(paragraph[1:]):
                 if line and line[0].isspace():
-                    continue # indented lines don't matter
+                    continue  # indented lines don't matter
                 elif is_item(line):
                     # itemize encountered and first line was no itemize line?
                     if item_encountered:
-                        err_message = _("A list or enumeration needs to be on "
-                                "a paragraph of its own and needs to have at "
-                                "least an empty line before.")
-                        return self.error(err_message, start_line+lnum)
+                        err_message = _(
+                            "A list or enumeration needs to be on "
+                            "a paragraph of its own and needs to have at "
+                            "least an empty line before."
+                        )
+                        return self.error(err_message, start_line + lnum)
                     else:
                         item_encountered = True
 
@@ -97,26 +116,32 @@ class ItemizeIsParagraph(Mistake):
 class PageNumberWordIsMispelled(Mistake):
     """Sometimes small typos are made when marking a new page. That breaks
 indexing of page numbers."""
+
     mistake_type = MistakeType.pagenumbers
+
     def __init__(self):
         Mistake.__init__(self)
-        self.page_identifiers = config.PAGENUMBERINGTOKENS + \
-                [e.title() for e in config.PAGENUMBERINGTOKENS]
+        self.page_identifiers = config.PAGENUMBERINGTOKENS + [
+            e.title() for e in config.PAGENUMBERINGTOKENS
+        ]
 
     def worker(self, *args):
         for pnum in args[0]:
             if not pnum.identifier in self.page_identifiers:
-                err_message = _("The page number \"{}\" can't be recognised, "
-                        "possibly due to a typo, hence it is ignored at the "
-                        "moment.").format(pnum.identifier)
+                err_message = _(
+                    'The page number "{}" can\'t be recognised, '
+                    "possibly due to a typo, hence it is ignored at the "
+                    "moment."
+                ).format(pnum.identifier)
                 return self.error(err_message, pnum.line_no)
 
 
 class UniformPagestrings(Mistake):
     mistake_type = MistakeType.pagenumbers_dir
+
     def __init__(self):
         Mistake.__init__(self)
-        self.pattern = re.compile('.*(%s).*' % '|'.join(config.PAGENUMBERINGTOKENS))
+        self.pattern = re.compile(".*(%s).*" % "|".join(config.PAGENUMBERINGTOKENS))
 
     def _error(self, first_fn, first_pnum, later_fn, later_pnum):
         first_fn = os.path.basename(first_fn)
@@ -124,18 +149,23 @@ class UniformPagestrings(Mistake):
         first = _("Two differing page number identifiers were found.")
         second = None
         if first_fn == later_fn:
-            second = _("First \"{pagenum}\", later \"{another}\".").format(
-                     pagenum=first_pnum.identifier,
-                     another=later_pnum.identifier)
+            second = _('First "{pagenum}", later "{another}".').format(
+                pagenum=first_pnum.identifier, another=later_pnum.identifier
+            )
         else:
-            second = _("First \"{pagenum}\", but then \"{another}\" in "
-                     "\"{file}\".").format(pagenum=first_pnum.identifier,
-                             another=later_pnum.identifier, file=later_fn)
-        return super().error('%s %s' % (first, second), lnum=first_pnum.line_no,
-                path=first_fn)
+            second = _(
+                'First "{pagenum}", but then "{another}" in ' '"{file}".'
+            ).format(
+                pagenum=first_pnum.identifier,
+                another=later_pnum.identifier,
+                file=later_fn,
+            )
+        return super().error(
+            "%s %s" % (first, second), lnum=first_pnum.line_no, path=first_fn
+        )
 
     def worker(self, *args):
-        first = () # (fn, first page number)
+        first = ()  # (fn, first page number)
         for fn, page_numbers in args[0].items():
             for pnum in page_numbers:
                 match = self.pattern.search(pnum.identifier.lower())
@@ -152,7 +182,9 @@ class TooManyHeadings(Mistake):
     """Are there too many headings of the same level in a directory next to each
 other? E.g. 40 headings level 2. The number can be controled using
 self.threshold."""
+
     mistake_type = MistakeType.headings_dir
+
     def __init__(self):
         super().__init__()
         self.threshold = 20
@@ -160,34 +192,38 @@ self.threshold."""
     def worker(self, *args):
         levels = [0, 0, 0, 0, 0, 0]
         directory = os.path.dirname(next(iter(args[0].keys())))
-        directory = (directory if directory else '.')
+        directory = directory if directory else "."
         conf = config.ConfFactory().get_conf_instance_safe(directory)
         maxdepth = int(conf[MetaInfo.TocDepth])
         for headings in args[0].values():
             for heading in headings:
                 if heading.get_level() > maxdepth:
                     continue
-                levels[heading.get_level()-1] += 1
+                levels[heading.get_level() - 1] += 1
                 # + 1 for the current level and reset all levels below
                 for level in range(heading.get_level(), len(levels)):
                     levels[level] = 0
-                if levels[heading.get_level()-1] > self.threshold:
+                if levels[heading.get_level() - 1] > self.threshold:
                     return self.__error(heading.get_level())
 
     def __error(self, heading_level):
-        return super().error(_("There are more than {count} headings of level "
+        return super().error(
+            _(
+                "There are more than {count} headings of level "
                 "{depth}. This can be circumvented by decreasing the heading "
                 "depth which will end up the the table of contents, by "
-                "decreasing the value tocDepth in the configuration.").format(
-                    count=self.threshold, depth=heading_level),)
+                "decreasing the value tocDepth in the configuration."
+            ).format(count=self.threshold, depth=heading_level),
+        )
 
 
 class ForgottenNumberInPageNumber(Mistake):
     """This is not a oneliner, because it is more efficient to go though all
     paragraphs and check for paragraphs with length 1 instead of iterating
     through *all* lines."""
+
     mistake_type = MistakeType.full_file
-    PAGE_IDENTIFICATION = re.compile(r'^\|\|\s+-\s+\w+\s+(.*?)\s*-\s*$')
+    PAGE_IDENTIFICATION = re.compile(r"^\|\|\s+-\s+\w+\s+(.*?)\s*-\s*$")
 
     def __init__(self):
         super().__init__()
@@ -201,20 +237,30 @@ class ForgottenNumberInPageNumber(Mistake):
             match = self.PAGE_IDENTIFICATION.search(line)
             if not match:
                 continue
-            number = match.groups()[0].split('-')[0] # if it's a range
+            number = match.groups()[0].split("-")[0]  # if it's a range
             # roman number regex returns empty string if nothing found
-            if not any(x.isdigit() for x in number) and not \
-                        config.ROMAN_NUMBER.search(number).end():
-                return self.error(_("A page number was marked up, but the "
-                        "actual number has not been inserted."), start)
+            if (
+                not any(x.isdigit() for x in number)
+                and not config.ROMAN_NUMBER.search(number).end()
+            ):
+                return self.error(
+                    _(
+                        "A page number was marked up, but the "
+                        "actual number has not been inserted."
+                    ),
+                    start,
+                )
+
 
 class PageNumbersWithoutDashes(Mistake):
     """Page number should look like "|| - page 8 -", people sometimes write
 "|| page 8"."""
+
     mistake_type = MistakeType.full_file
+
     def __init__(self):
         super().__init__()
-        pattern = r'\|\|\s*(?:-)?\s*(' + '|'.join(config.PAGENUMBERINGTOKENS) + ')'
+        pattern = r"\|\|\s*(?:-)?\s*(" + "|".join(config.PAGENUMBERINGTOKENS) + ")"
         self.pattern = re.compile(pattern.lower())
 
     def worker(self, *args):
@@ -225,49 +271,79 @@ class PageNumbersWithoutDashes(Mistake):
             if self.pattern.search(first_ln.lower()):
                 first_ln = first_ln[2:].lstrip()
                 # if all spaces and |'s are stripped, last character and first char must be dashes
-                if not first_ln.startswith('-') or not first_ln.endswith('-'):
-                    return self.error(_("A \"-\" in the page number is missing,"
-                            " required: \"|| - Page xyz -\""), lnum=num)
+                if not first_ln.startswith("-") or not first_ln.endswith("-"):
+                    return self.error(
+                        _(
+                            'A "-" in the page number is missing,'
+                            ' required: "|| - Page xyz -"'
+                        ),
+                        lnum=num,
+                    )
+
 
 class DoNotEmbedHtml(OnelinerMistake):
     """Do not use HTML. Especially, don't use <br/>."""
+
     def __init__(self):
         super().__init__()
         self.pattern = re.compile(r'</?(\w+)\s*/?(:?\s+\w+=["\']\w+["\'])*\s*>')
 
     def check(self, num, line):
         match = self.pattern.search(line.lower())
-        tag = (match.groups()[0] if match else None)
-        if tag and tag not in ['div', 'span']:
+        tag = match.groups()[0] if match else None
+        if tag and tag not in ["div", "span"]:
             pos_on_line = match.span()[1]
-            if tag.lower() == 'br':
-                return self.error(_("\"{tag}\" is not allowed, use a new "
-                        "paragraph or a \"\\\" at the end of a line.") \
-                        .format(tag=tag.lower()), lnum=num, pos=pos_on_line)
+            if tag.lower() == "br":
+                return self.error(
+                    _(
+                        '"{tag}" is not allowed, use a new '
+                        'paragraph or a "\\" at the end of a line.'
+                    ).format(tag=tag.lower()),
+                    lnum=num,
+                    pos=pos_on_line,
+                )
             else:
-                return self.error(_("It is not allowed to use HTML tags, "
-                        "except for div and span."), lnum=num, pos=pos_on_line)
+                return self.error(
+                    _(
+                        "It is not allowed to use HTML tags, "
+                        "except for div and span."
+                    ),
+                    lnum=num,
+                    pos=pos_on_line,
+                )
+
 
 class EmbeddedHTMLComperators(OnelinerMistake):
     """Instead of &lt;&gt;, use \\< \\>."""
+
     def __init__(self):
         super().__init__()
-        self.pattern = re.compile(r'&(lt|gt);')
+        self.pattern = re.compile(r"&(lt|gt);")
 
     def check(self, num, line):
         matched = self.pattern.search(line.lower())
         if matched:
-            return self.error(_("Comparison operators shouldn't be marked up "
-                    "in HTML, but with \\< and \\>."), lnum=num,
-                        pos=matched.span()[1])
+            return self.error(
+                _(
+                    "Comparison operators shouldn't be marked up "
+                    "in HTML, but with \\< and \\>."
+                ),
+                lnum=num,
+                pos=matched.span()[1],
+            )
+
 
 class HeadingsUseEitherUnderliningOrHashes(Mistake):
     mistake_type = MistakeType.headings
+
     def worker(self, *args):
         for heading in args[0]:
-            if heading.get_text().startswith('#'):
-                return self.error(_("The heading was underlined and also "
-                        "marked with #'s."), lnum=heading.get_line_number())
+            if heading.get_text().startswith("#"):
+                return self.error(
+                    _("The heading was underlined and also " "marked with #'s."),
+                    lnum=heading.get_line_number(),
+                )
+
 
 class ParagraphMayNotEndOnBackslash(Mistake):
     r"""If a paragraph ends on a backslash, the next line will be treated as
@@ -281,33 +357,45 @@ class ParagraphMayNotEndOnBackslash(Mistake):
         -   item two
         ~~~~"""
     mistake_type = MistakeType.full_file
+
     def worker(self, *args):
         for start_line, paragraph in args[0].items():
-            if paragraph and paragraph[-1].rstrip().endswith('\\'):
-                return self.error(_("If a paragraph ends on a \\, the next "
+            if paragraph and paragraph[-1].rstrip().endswith("\\"):
+                return self.error(
+                    _(
+                        "If a paragraph ends on a \\, the next "
                         "empty line will become part of the paragraph and "
-                        "hence the next paragraph is formatted incorrectly."),
-                    lnum=start_line + len(paragraph))
+                        "hence the next paragraph is formatted incorrectly."
+                    ),
+                    lnum=start_line + len(paragraph),
+                )
+
 
 class DetectStrayingDollars(OnelinerMistake):
     """An uneven number of dollar signs can indicate either a multi-line formula enclosed by only $...$ or a forgotten closing formula. Both is errorneous."""
+
     def check(self, lnum, line):
-        if not '$' in line:
+        if not "$" in line:
             return
-        line = line.replace("$$", "").replace('\\$', '')
+        line = line.replace("$$", "").replace("\\$", "")
         # count single $-signs
-        num_dollars = line.count('$')
+        num_dollars = line.count("$")
         # check that no $<num> (US-american price) is contained in the line:
         if num_dollars == 1:
-            index = line.index('$')
-            if index < (len(line)-1) and line[index+1].isdigit():
+            index = line.index("$")
+            if index < (len(line) - 1) and line[index + 1].isdigit():
                 return
 
-        if num_dollars % 2: # odd number of dollars
-            return self.error(_("Line contains uneven number of dollar signs. "
+        if num_dollars % 2:  # odd number of dollars
+            return self.error(
+                _(
+                    "Line contains uneven number of dollar signs. "
                     "Either a formula wasn't closed or an embedded formula was "
                     "stretched across multiple lines (try double dollars). If "
-                    "you meant a real dollar sign, prepend a \\ to it."), lnum)
+                    "you meant a real dollar sign, prepend a \\ to it."
+                ),
+                lnum,
+            )
 
 
 class TextInItemizeShouldntStartWithItemizeCharacter(Mistake):
@@ -319,92 +407,122 @@ class TextInItemizeShouldntStartWithItemizeCharacter(Mistake):
 
 This will lead to Pandoc identifying these as sublists.
 """
+
     mistake_type = MistakeType.full_file
+
     def __init__(self):
         super().__init__()
         # match "- 1." or "* +" or "- +" or "1. -"
-        self._pattern = re.compile(r'''^\s*(?:-|\+|\*|\d+\.)\s+
+        self._pattern = re.compile(
+            r"""^\s*(?:-|\+|\*|\d+\.)\s+
             # prohibit matching a horizontal rule (* * * or - - -) and bold / slanted text and also not european-style dates
             (?![\*-]\s[\*-]| # horizontal rule
                 \*\*|\*\*?[a-z|A-Z]| # bold or slanted text
                 \d+\.[0-9a-zA-z]) # european-style dates dd.mm.YYYY
-                (.*)$''', re.VERBOSE)
+                (.*)$""",
+            re.VERBOSE,
+        )
 
     def worker(self, *args):
-        is_enum_item = re.compile(r'^\d{1,2}\.') # only match enumerations, not (German) dates like "2016."
+        is_enum_item = re.compile(
+            r"^\d{1,2}\."
+        )  # only match enumerations, not (German) dates like "2016."
 
         for start_line, paragraph in args[0].items():
             enumeration_signs = 0
             errorneous_line = 0
             for rel_lnum, line in enumerate(paragraph):
                 match = self._pattern.search(line)
-                if match and match.groups()[0]: # didn't match the empty string
+                if match and match.groups()[0]:  # didn't match the empty string
                     enumeration_signs += 1
                     text = match.groups()[0]
-                    if text[0] in ['-', '+'] or is_enum_item.search(text):
+                    if text[0] in ["-", "+"] or is_enum_item.search(text):
                         errorneous_line = start_line + rel_lnum
-                        if enumeration_signs >= 2: # it's a proper enumeration
-                            break # an error case was encountered
+                        if enumeration_signs >= 2:  # it's a proper enumeration
+                            break  # an error case was encountered
             if errorneous_line:
-                return self.error(_("In enumerations and lists, the enumeration"
+                return self.error(
+                    _(
+                        "In enumerations and lists, the enumeration"
                         " character may not immediately be followed by another "
                         "such character, because it will be recognised as a "
                         "sublist. A \\ in front of a character or in front of "
-                        "the dot for enumerations will suppress this."),
-                    lnum=errorneous_line-1)
+                        "the dot for enumerations will suppress this."
+                    ),
+                    lnum=errorneous_line - 1,
+                )
 
 
 class ToDosInImageDescriptionsAreBad(OnelinerMistake):
     """Some people tend to leave "to do" or similar in their material to mark areas as being not completed yet."""
+
     def __init__(self):
         super().__init__()
-        self._todo_pattern = re.compile(r'''
+        self._todo_pattern = re.compile(
+            r"""
                 ((?:to|To|TO)\s*(?:do|Do|DO))\s*
                 # expect punctuation, etc. to not match false positives
                 (?:\.|,|:|$)
-                ''', re.VERBOSE)
+                """,
+            re.VERBOSE,
+        )
 
     def check(self, lnum, line):
         match = self._todo_pattern.search(line)
         if match:
-            return self.error(_("The image description is probably incomplete, "
-                    "since \"{marker}\" has been found. ").format(
-                        marker=match.groups()[0]), lnum=lnum)
+            return self.error(
+                _(
+                    "The image description is probably incomplete, "
+                    'since "{marker}" has been found. '
+                ).format(marker=match.groups()[0]),
+                lnum=lnum,
+            )
 
 
 class BrokenImageLinksAreDetected(OnelinerMistake):
     def __init__(self):
         super().__init__()
         # phrase is everything except ()[]; inserted into {0} below for easier readability
-        self._pattern = re.compile(r'''^\s*
+        self._pattern = re.compile(
+            r"""^\s*
             (\![^[]+?\]\([^)]+\) # image link where [ has been forgotten
              |\!\[[^]]+\([^)]+\) # image link where ] has been forgotten
              |\!\[[^]]+\][^(]+?\) # image link where ( has been forgotten
              |\[[^]]+\]\s*\([^)]+?\.(?:jpg|png|tif|gif|svg)\) # image link where ! has been forgotten
              |\!\[[^]]+?\]\([^)]+$) # image link where ) has been forgotten
-            ''', re.VERBOSE)
+            """,
+            re.VERBOSE,
+        )
 
     def check(self, num, line):
         if self._pattern.search(line.lower()):
             # check whether ! [ ] ( ) are all in the line, if so, it's a false positive
-            for punct in ['(', ')', '[', ']', '!']:
+            for punct in ["(", ")", "[", "]", "!"]:
                 if not punct in line:
-                    return self.error(_("The included image is using wrong "
-                            "syntax, the converter will ignore it."), num)
+                    return self.error(
+                        _(
+                            "The included image is using wrong "
+                            "syntax, the converter will ignore it."
+                        ),
+                        num,
+                    )
+
 
 class HyphensFromJustifiedTextWereRemoved(Mistake):
     """When copy-pasting text from i.e. PDFs, it is easy to forget to remove
     the hyphenation at the end of the line. This checker attempts to warn in
     the obvious cases."""
-    HYPHENS = ['-', '\xad']
+
+    HYPHENS = ["-", "\xad"]
     mistake_type = MistakeType.full_file
+
     def __init__(self):
         super().__init__()
 
     def ends_with_hyphen(self, line):
         line = line.rstrip()
         if any(line.endswith(h) for h in self.HYPHENS) and len(line) > 1:
-            if line[-2].isalpha(): # part of a word
+            if line[-2].isalpha():  # part of a word
                 return True
         return False
 
@@ -415,19 +533,30 @@ class HyphensFromJustifiedTextWereRemoved(Mistake):
             for lnum, line in enumerate(lines):
                 # if hyphen and there's a next line
                 if self.ends_with_hyphen(line) and has_next_line(lnum, lines):
-                    next_line = lines[lnum+1].lstrip()
+                    next_line = lines[lnum + 1].lstrip()
                     # it was justified text, if next line starts with a word
-                    if next_line and next_line[0].isalpha() and not \
-                            (next_line.startswith('und') or next_line.startswith('and')):
-                        return self.error(_("A hyphen was found which possibly "
+                    if (
+                        next_line
+                        and next_line[0].isalpha()
+                        and not (
+                            next_line.startswith("und") or next_line.startswith("and")
+                        )
+                    ):
+                        return self.error(
+                            _(
+                                "A hyphen was found which possibly "
                                 "originates from copied justified text. This "
-                                "will be incorrectly formatted in the output."),
-                            start_line + lnum)
+                                "will be incorrectly formatted in the output."
+                            ),
+                            start_line + lnum,
+                        )
 
 
 class DetectEmptyImageDescriptions(Mistake):
     """Detect headings in bilder.md with no described images below."""
+
     mistake_type = MistakeType.headings_dir
+
     def get_heading_ranges(self, headings, last_line):
         for pair in common.pairwise(headings):
             yield tuple(p.get_line_number() for p in pair)
@@ -441,26 +570,31 @@ class DetectEmptyImageDescriptions(Mistake):
             yield (headings[-1].get_line_number(), last_line + 1)
 
     def worker(self, *args):
-        imgdesc = [(p, h) for p, h in args[0].items()
-                if os.path.basename(p).lower() == 'bilder.md']
+        imgdesc = [
+            (p, h)
+            for p, h in args[0].items()
+            if os.path.basename(p).lower() == "bilder.md"
+        ]
         if not imgdesc:
             return
         path, headings = imgdesc[0]
-        with open(path, 'r', encoding='utf-8') as file:
+        with open(path, "r", encoding="utf-8") as file:
             lines = file.readlines()
 
-        headings = [h for h in headings if h.get_level() > 1] # ignore level 1 headings
+        headings = [h for h in headings if h.get_level() > 1]  # ignore level 1 headings
         for start_line, end_line in self.get_heading_ranges(headings, len(lines)):
             image_description_found = False
-            for line in lines[start_line : end_line-1]: # lines counted from 1; ignore heading line
+            for line in lines[
+                start_line : end_line - 1
+            ]:  # lines counted from 1; ignore heading line
                 if not line.strip():
-                    continue # nothing found, check next line
-                elif '===' in line or '---' in line:
-                    continue # underline of heading needss to be ignored
-                else: # some text, not a heading, so image described
+                    continue  # nothing found, check next line
+                elif "===" in line or "---" in line:
+                    continue  # underline of heading needss to be ignored
+                else:  # some text, not a heading, so image described
                     image_description_found = True
                     break
             if not image_description_found:
-                return self.error(_("No image description provided."),
-                    lnum=start_line, path=path)
-
+                return self.error(
+                    _("No image description provided."), lnum=start_line, path=path
+                )

--- a/MAGSBS/quality_assurance/meta.py
+++ b/MAGSBS/quality_assurance/meta.py
@@ -4,12 +4,13 @@
 # (c) 2016-2017 Sebastian Humenda <shumenda |at| gmx |dot| de>
 # Disabling the checkers below is discouraged, but encouraged for this file;
 # pylint makes mistakes itself
-#pylint: disable=line-too-long,no-init,too-few-public-methods
+# pylint: disable=line-too-long,no-init,too-few-public-methods
 """This file contains all helper functions and classes to represent a
 mistake."""
 
 from abc import ABCMeta, abstractmethod
 import enum
+
 
 class MistakeType(enum.Enum):
     """The mistake type determines the arguments and the environment in which to
@@ -31,6 +32,7 @@ formulas        (path, formulas)    apply checks on the ordered list of formulas
                                     of `path`; for the format see mparser.parse_formulas
 lectureroot     Do any check with the given lecture root.
 """
+
     full_file = 1
     oneliner = 2
     headings = 3
@@ -41,11 +43,13 @@ lectureroot     Do any check with the given lecture root.
     formulas = 8
     lecture_root = 9
 
+
 class Mistake:
     """This class implements the actual mistake checker.
 
 It has to be subclassed and the child needs to override the run method. It
 should set the relevant properties in the constructor."""
+
     __metaclass__ = ABCMeta
     mistake_type = MistakeType.full_file
 
@@ -56,7 +60,7 @@ should set the relevant properties in the constructor."""
 
     def set_file_types(self, types):
         # is it list-alike
-        if not (hasattr(types, '__iter__') or hasattr(types, '__getitem__')):
+        if not (hasattr(types, "__iter__") or hasattr(types, "__getitem__")):
             raise TypeError("List or tuple expected.")
         self.__file_types = types
 
@@ -72,7 +76,6 @@ should set the relevant properties in the constructor."""
         assert isinstance(value, bool)
         self.__apply = value
 
-
     def run(self, *args):
         if not self.should_be_run:
             return
@@ -84,11 +87,12 @@ should set the relevant properties in the constructor."""
 
     def error(self, msg, lnum=None, path=None, pos=None):
         """Short hand to return an ErrorMessage object."""
-        msg = ' '.join(msg.split())
+        msg = " ".join(msg.split())
         e = ErrorMessage(msg, lnum, path)
         if pos:
             e.pos_on_line = pos
         return e
+
 
 class OnelinerMistake(Mistake):
     """Class to ease the creation of onliner checks further:
@@ -98,17 +102,21 @@ class myMistake(OnelinerMistake):
     def check(self, num, line):
         # ToDo: implement checks here
 It'll save typing."""
+
     mistake_type = MistakeType.oneliner
 
     def __init__(self):
         Mistake.__init__(self)
+
     def check(self, lnum, text):
         """The method to implement the actual  checker in."""
         pass
 
     def worker(self, *args):
         if len(args) != 2:
-            raise ValueError("For a mistake checker of type oneliner, exactly two arguments are required.")
+            raise ValueError(
+                "For a mistake checker of type oneliner, exactly two arguments are required."
+            )
         return self.check(args[0], args[1])
 
 
@@ -122,12 +130,12 @@ class FormulaMistake(Mistake):
             # *implement checks here*
     When calling .error inside such a checker, a call might look like this:
         self.error("some_msg", lnum=some_line, pos=position_on_line)"""
+
     mistake_type = MistakeType.formulas
 
     @abstractmethod
     def worker(self, *args):
         pass
-
 
 
 class ErrorMessage:
@@ -139,10 +147,9 @@ e.pos_on_line = 52 # at which character the error was encountered
 e.path = "foo.md" # usually set by the Mistkerl, but can be altered
 assert hasattr(e, 'message') and hasattr(e, 'lineno')
 """
+
     def __init__(self, message, lineno, path):
         self.lineno = lineno
         self.message = message
         self.path = path
         self.pos_on_line = None
-
-

--- a/MAGSBS/quality_assurance/mistkerl.py
+++ b/MAGSBS/quality_assurance/mistkerl.py
@@ -6,7 +6,7 @@
 # Else it is strongly discouraged! Wild-card imports are here because we are
 # importing the mistakes and it is cumbersome to add them to the imports every
 # time a new one is written.
-#pylint: disable=wildcard-import,unused-wildcard-import
+# pylint: disable=wildcard-import,unused-wildcard-import
 
 """
 This sub-module provides implementations for checking common lecture editing
@@ -39,34 +39,51 @@ from .markdown import *
 from .meta import *
 from .linkchecker import LinkChecker, extract_links
 
-class Mistkerl():
+
+class Mistkerl:
     """Wrapper which wraps different levels of errors."""
-    TOLERANT_PAGE_NUMBERING_PATTERN = re.compile(r'''
+
+    TOLERANT_PAGE_NUMBERING_PATTERN = re.compile(
+        r"""
         # match any word or two-word phrase
         -\s*([a-z|A-Z]\s*[a-z|A-Z]*)\s+
         (\d+|%s)\s*- # arabic or roman numbers
-        ''' % roman.roman_numeral_pattern_string.strip().lstrip('^').rstrip('$'),
-        re.VERBOSE) # ^ strip begin and end-of-line matcher
+        """
+        % roman.roman_numeral_pattern_string.strip().lstrip("^").rstrip("$"),
+        re.VERBOSE,
+    )  # ^ strip begin and end-of-line matcher
 
     def __init__(self):
-        self.__issues = [PageNumberIsParagraph, LevelOneHeading,
-                ItemizeIsParagraph, ForgottenNumberInPageNumber,
-                UniformPagestrings, TooManyHeadings,
-                LaTeXMatricesShouldBeConstructeedUsingPmatrix,
-                LaTeXMatricesShouldHaveLineBreaks, PageNumbersWithoutDashes,
-                DoNotEmbedHtml, EmbeddedHTMLComperators,
-                PageNumberWordIsMispelled, HeadingsUseEitherUnderliningOrHashes,
-                CasesSqueezedOnOneLine, ConfigurationValuesAreAllSet,
-                LaTeXUmlautsUsed, BrokenUmlautsFromPDFFiles,
-                TextInItemizeShouldntStartWithItemizeCharacter,
-                SpacingInFormulaShouldBeDoneWithQuad,
-                BrokenImageLinksAreDetected,
-                HyphensFromJustifiedTextWereRemoved,
-                DisplayMathShouldNotBeUsedWithinAParagraph,
-                UseProperCommandsForMathOperatorsAndFunctions,
-                FreeStandingFormulasShouldBeDisplaymath,
-                DetectEmptyImageDescriptions, DetectStrayingDollars,
-                OnlyCorrectDirectoriesFound, ParagraphMayNotEndOnBackslash]
+        self.__issues = [
+            PageNumberIsParagraph,
+            LevelOneHeading,
+            ItemizeIsParagraph,
+            ForgottenNumberInPageNumber,
+            UniformPagestrings,
+            TooManyHeadings,
+            LaTeXMatricesShouldBeConstructeedUsingPmatrix,
+            LaTeXMatricesShouldHaveLineBreaks,
+            PageNumbersWithoutDashes,
+            DoNotEmbedHtml,
+            EmbeddedHTMLComperators,
+            PageNumberWordIsMispelled,
+            HeadingsUseEitherUnderliningOrHashes,
+            CasesSqueezedOnOneLine,
+            ConfigurationValuesAreAllSet,
+            LaTeXUmlautsUsed,
+            BrokenUmlautsFromPDFFiles,
+            TextInItemizeShouldntStartWithItemizeCharacter,
+            SpacingInFormulaShouldBeDoneWithQuad,
+            BrokenImageLinksAreDetected,
+            HyphensFromJustifiedTextWereRemoved,
+            DisplayMathShouldNotBeUsedWithinAParagraph,
+            UseProperCommandsForMathOperatorsAndFunctions,
+            FreeStandingFormulasShouldBeDisplaymath,
+            DetectEmptyImageDescriptions,
+            DetectStrayingDollars,
+            OnlyCorrectDirectoriesFound,
+            ParagraphMayNotEndOnBackslash,
+        ]
         self.__cache_pnums = collections.OrderedDict()
         self.__cached_headings = collections.OrderedDict()
         self.__output = []
@@ -74,26 +91,28 @@ class Mistkerl():
     def get_issues(self, required_type, fname=None):
         """Instanciate issue classes and filter for their configured file
         extension."""
-        extension = (os.path.splitext(fname)[1].replace('.', '') if fname else 'md')
-        issues = (i for i in self.__issues
-                if i.mistake_type == required_type)
-        return list(i for i in (i() for i in issues) # instanciate
-            if extension in i.get_file_types())
+        extension = os.path.splitext(fname)[1].replace(".", "") if fname else "md"
+        issues = (i for i in self.__issues if i.mistake_type == required_type)
+        return list(
+            i
+            for i in (i() for i in issues)  # instanciate
+            if extension in i.get_file_types()
+        )
 
     def run(self, path):
         """Take either a file and run checks or do the same for a directory
         recursively."""
-        file_tree = [(None, [], [])] # empty os.walk()-alike data structure
+        file_tree = [(None, [], [])]  # empty os.walk()-alike data structure
         if os.path.isfile(path):
             file_tree = [[os.path.dirname(path), [], [os.path.basename(path)]]]
-            if not file_tree[0][0]: # no directory part extracted
+            if not file_tree[0][0]:  # no directory part extracted
                 file_tree[0][0] = os.path.dirname(os.path.abspath(path))
         else:
             for issue in self.get_issues(MistakeType.lecture_root):
                 self.__append_error(path, issue.run(path))
             fw = filesystem.FileWalker(path)
             fw.set_ignore_non_chapter_prefixed(False)
-            fw.set_endings(["md","tex"])
+            fw.set_endings(["md", "tex"])
             file_tree = fw.walk()
         last_dir = None
         directoryname = None
@@ -103,20 +122,21 @@ class Mistkerl():
                 last_dir = directoryname
                 # check configuration
                 if os.path.exists(os.path.join(directoryname, config.CONF_FILE_NAME)):
-                    self.__handle_configuration(directoryname,
-                            config.CONF_FILE_NAME)
-                    continue # do no more checks
-
+                    self.__handle_configuration(directoryname, config.CONF_FILE_NAME)
+                    continue  # do no more checks
 
             for file in file_list:
                 file_path = os.path.join(directoryname, file)
                 try:
                     with open(file_path, encoding="utf-8") as f:
                         paragraphs = mparser.rm_codeblocks(
-                                mparser.file2paragraphs(f.read(), join_lines=True))
+                            mparser.file2paragraphs(f.read(), join_lines=True)
+                        )
                 except UnicodeDecodeError:
-                    msg = _("File not encoded in UTF-8, please configure this "
-                            "encoding in your editor.")
+                    msg = _(
+                        "File not encoded in UTF-8, please configure this "
+                        "encoding in your editor."
+                    )
                     e = ErrorMessage(msg, 1, file_path)
                     self.__append_error(path, e)
                     continue
@@ -134,21 +154,22 @@ class Mistkerl():
         if not err:
             return
         if not isinstance(err, ErrorMessage):
-            raise TypeError("Errors may only be of type ErrorMessage, got '{}'"\
-                    .format(str(err)))
+            raise TypeError(
+                "Errors may only be of type ErrorMessage, got '{}'".format(str(err))
+            )
         if not err.path:
             err.path = path
-        if os.path.dirname(err.path) == '.':
-            err.path = err.path[2:] # strip ./ or .\
+        if os.path.dirname(err.path) == ".":
+            err.path = err.path[2:]  # strip ./ or .\
         self.__output.append(err)
-
 
     def __run_filters_on_file(self, file_path, paragraphs):
         """Execute all filters which operate on one file. Also exclue filters
             which do not match for the file ending."""
         # check whether file is too long
-        self.__append_error(file_path, self.check_for_overlong_files(file_path,
-            paragraphs))
+        self.__append_error(
+            file_path, self.check_for_overlong_files(file_path, paragraphs)
+        )
 
         for issue in self.get_issues(MistakeType.full_file, file_path):
             self.__append_error(file_path, issue.run(paragraphs))
@@ -157,22 +178,23 @@ class Mistkerl():
             for lnum, line in enumerate(paragraph):
                 for issue in oneliners:
                     if issue.should_be_run():
-                        res = issue.run(start_line+lnum, line)
+                        res = issue.run(start_line + lnum, line)
                         if res:
                             self.__append_error(file_path, res)
                             issue.set_run(False)
             if not any(e.should_be_run() for e in oneliners):
-                break # no oneliner left which needs to be executed
+                break  # no oneliner left which needs to be executed
         pnums = []
         try:
-            pnums = mparser.extract_page_numbers_from_par(paragraphs,
-                    regex=Mistkerl.TOLERANT_PAGE_NUMBERING_PATTERN)
+            pnums = mparser.extract_page_numbers_from_par(
+                paragraphs, regex=Mistkerl.TOLERANT_PAGE_NUMBERING_PATTERN
+            )
             # if the file name does not end of any of the image description names,
             # it's a "proper" chapter and only for those the page number cache is relevant
             if not file_path.endswith("bilder.md"):
                 self.__cache_pnums[file_path] = pnums
         except errors.FormattingError:
-            pass # checkers are able to handle this case and will report
+            pass  # checkers are able to handle this case and will report
         hdngs = mparser.extract_headings_from_par(paragraphs)
         self.__cached_headings[file_path] = hdngs
 
@@ -219,18 +241,29 @@ class Mistkerl():
                 self.__append_error(path, issue.run(path))
             except ET.ParseError as e:
                 pos = e.position
-                mistake = ErrorMessage(_("The configuration could not be read: "
-                        "{reason}").format(e.args[0]), pos[0], path)
+                mistake = ErrorMessage(
+                    _("The configuration could not be read: " "{reason}").format(
+                        e.args[0]
+                    ),
+                    pos[0],
+                    path,
+                )
                 mistake.pos_on_line = pos[1]
                 self.__append_error(path, mistake)
 
     def check_for_overlong_files(self, file_path, paragraphs):
         if not paragraphs:
-            return # ignore empty files
+            return  # ignore empty files
         last_par = next(reversed(paragraphs))
         threshold = 2500
         if last_par > threshold:
-            return ErrorMessage(_("The file is too long. To ease navigation and"
+            return ErrorMessage(
+                _(
+                    "The file is too long. To ease navigation and"
                     " maintain readability, the file should be split into files"
                     "with less than {count} lines by naming them like "
-                    "kXXYY.md.").format(count=threshold), last_par, file_path)
+                    "kXXYY.md."
+                ).format(count=threshold),
+                last_par,
+                file_path,
+            )

--- a/MAGSBS/roman.py
+++ b/MAGSBS/roman.py
@@ -17,25 +17,39 @@ __license__ = "Python"
 import re
 
 # Define exceptions
-class RomanError(Exception): pass
-class OutOfRangeError(RomanError): pass
-class NotIntegerError(RomanError): pass
-class InvalidRomanNumeralError(RomanError): pass
+class RomanError(Exception):
+    pass
+
+
+class OutOfRangeError(RomanError):
+    pass
+
+
+class NotIntegerError(RomanError):
+    pass
+
+
+class InvalidRomanNumeralError(RomanError):
+    pass
+
 
 # Define digit mapping
-romanNumeralMap = (('M',  1000),
-                   ('CM', 900),
-                   ('D',  500),
-                   ('CD', 400),
-                   ('C',  100),
-                   ('XC', 90),
-                   ('L',  50),
-                   ('XL', 40),
-                   ('X',  10),
-                   ('IX', 9),
-                   ('V',  5),
-                   ('IV', 4),
-                   ('I',  1))
+romanNumeralMap = (
+    ("M", 1000),
+    ("CM", 900),
+    ("D", 500),
+    ("CD", 400),
+    ("C", 100),
+    ("XC", 90),
+    ("L", 50),
+    ("XL", 40),
+    ("X", 10),
+    ("IX", 9),
+    ("V", 5),
+    ("IV", 4),
+    ("I", 1),
+)
+
 
 def to_roman(n):
     """convert integer to Roman numeral"""
@@ -53,8 +67,9 @@ def to_roman(n):
             n -= integer
     return result
 
+
 # Define pattern to detect valid Roman numerals
-roman_numeral_pattern_string = '''^
+roman_numeral_pattern_string = """^
     M{0,4}              # thousands - 0 to 4 M's
     (?:CM|CD|D?C{0,3})    # hundreds - 900 (CM), 400 (CD), 0-300 (0 to 3 C's),
                         #            or 500-800 (D, followed by 0 to 3 C's)
@@ -62,21 +77,21 @@ roman_numeral_pattern_string = '''^
                         #        or 50-80 (L, followed by 0 to 3 X's)
     (?:IX|IV|V?I{0,3})    # ones - 9 (IX), 4 (IV), 0-3 (0 to 3 I's),
                         #        or 5-8 (V, followed by 0 to 3 I's)
-    $'''
+    $"""
 roman_numeral_pattern = re.compile(roman_numeral_pattern_string, re.VERBOSE)
+
 
 def from_roman(letters):
     """convert Roman numeral to integer"""
     if not letters:
-        raise InvalidRomanNumeralError('Input can not be blank')
+        raise InvalidRomanNumeralError("Input can not be blank")
     if not roman_numeral_pattern.search(letters):
-        raise InvalidRomanNumeralError('Invalid Roman numeral: %letters' % letters)
+        raise InvalidRomanNumeralError("Invalid Roman numeral: %letters" % letters)
 
     result = 0
     index = 0
     for numeral, integer in romanNumeralMap:
-        while letters[index:index+len(numeral)] == numeral:
+        while letters[index : index + len(numeral)] == numeral:
             result += integer
             index += len(numeral)
     return result
-

--- a/MAGSBS/toc.py
+++ b/MAGSBS/toc.py
@@ -11,12 +11,15 @@ import os
 import re
 
 from . import config, errors, mparser, filesystem as fs, datastructures
+
 MetaInfo = config.MetaInfo
 
 
 # alias datastructures.Heading.Type
 HeadingType = datastructures.Heading.Type
-class HeadingIndexer():
+
+
+class HeadingIndexer:
     """create_index(dir)
 
 Walk the file system tree from "dir" and have a look in all files which end on
@@ -24,12 +27,12 @@ Walk the file system tree from "dir" and have a look in all files which end on
 
 Format of index: dict of lists: every filename is the key, the list of heading
 [objects] is the value in the OrderedDict()."""
+
     def __init__(self, path):
         if not os.path.exists(path):
             raise errors.StructuralError("Directory doesn't exist.", path)
         self.__dir = path
         self.__index = collections.OrderedDict()
-
 
     def is_empty(self):
         return not bool(self.__index)
@@ -39,32 +42,31 @@ Format of index: dict of lists: every filename is the key, the list of heading
 By calling the function, the actual index is build."""
         conf = config.ConfFactory().get_conf_instance_safe(self.__dir)
         if conf[MetaInfo.GenerateToc] == 0:
-            return # don't generate a TOC
+            return  # don't generate a TOC
         for directory, _, files in fs.get_markdown_files(self.__dir):
             for file in files:
                 path = os.path.join(directory, file)
                 headings = self.__retrieve_headings_from(path)
-                if os.path.split(directory)[-1].startswith("anh") :
-                    for heading in headings: # reference
+                if os.path.split(directory)[-1].startswith("anh"):
+                    for heading in headings:  # reference
                         heading.set_type(datastructures.Heading.Type.APPENDIX)
                 # preface headings
-                elif re.search(r'^v\d\d', os.path.split(directory)[-1]):
-                    for heading in headings: # reference
+                elif re.search(r"^v\d\d", os.path.split(directory)[-1]):
+                    for heading in headings:  # reference
                         heading.set_type(datastructures.Heading.Type.PREFACE)
 
-                full_fn = os.path.join( directory, file)
+                full_fn = os.path.join(directory, file)
                 self.__index[full_fn] = headings
-
 
     def __retrieve_headings_from(self, path):
         """Retrieve headings from path and annotate them with 'unedited' if the
         file was not edited yet."""
-        with open(path, 'r', encoding='utf-8') as cnt:
+        with open(path, "r", encoding="utf-8") as cnt:
             paragraphs = mparser.file2paragraphs(cnt.read())
         headings = mparser.extract_headings(path, paragraphs)
         heading_lines = [h.get_line_number() for h in headings]
 
-        all_lines_are_headings = lambda x: all(l.startswith('#') for l in x)
+        all_lines_are_headings = lambda x: all(l.startswith("#") for l in x)
         # check whether any text has been inserted and if not; if so, return
         # unmodified heading list
         for start_line, lines in paragraphs.items():
@@ -75,10 +77,12 @@ By calling the function, the actual index is build."""
             elif len(lines) == 2:
                 # only paragraphs with underlined headings or two ##-headings
                 # are accepted:
-                if not all_lines_are_headings(lines) and \
-                        not (('----' in lines[1] or '====' in lines[1]) and start_line in heading_lines):
-                    return headings # modification detected, was edited
-            else: # paragraph with exactly one line
+                if not all_lines_are_headings(lines) and not (
+                    ("----" in lines[1] or "====" in lines[1])
+                    and start_line in heading_lines
+                ):
+                    return headings  # modification detected, was edited
+            else:  # paragraph with exactly one line
                 if not start_line in heading_lines:
                     return headings
 
@@ -88,16 +92,19 @@ By calling the function, the actual index is build."""
         trans.set_language(conf[MetaInfo.Language])
 
         for heading in headings:
-            heading.set_text('{} ({})'.format(heading.get_text(),
-                trans.get_translation('not edited')))
+            heading.set_text(
+                "{} ({})".format(
+                    heading.get_text(), trans.get_translation("not edited")
+                )
+            )
         return headings
-
 
     def get_index(self):
         tmp = collections.OrderedDict()
         for key in sorted(self.__index):
             tmp[key] = self.__index[key]
         return tmp
+
 
 class ChapterNumberEnumerator:
     """Track headings and calculate chapter numbers. For that to work it is
@@ -110,7 +117,9 @@ class ChapterNumberEnumerator:
     c.register(some_level2_heading)
     assert c.get_heading_enumeration()) == '2.1'
     """
+
     MAX_DEPTH = 6
+
     def __init__(self):
         self.__registered = [0 for x in range(6)]
         self.__lastchapter = None
@@ -119,13 +128,20 @@ class ChapterNumberEnumerator:
         """Register heading for chapter number calculation.
         For this the heading object must provide the get_level and
         get_chapter_number methods."""
-        if not hasattr(heading, 'get_level') or not hasattr(heading,
-                'get_chapter_number'):
-            raise TypeError("The heading object must provide a "
-                "get_level and get_chapter_number method, got " + str(type(heading)))
+        if not hasattr(heading, "get_level") or not hasattr(
+            heading, "get_chapter_number"
+        ):
+            raise TypeError(
+                "The heading object must provide a "
+                "get_level and get_chapter_number method, got " + str(type(heading))
+            )
         elif heading.get_chapter_number() is None or heading.get_level() is None:
-            raise ValueError(("Neither get_level() nor get_chapter_number() "
-                "may be None for the given heading"))
+            raise ValueError(
+                (
+                    "Neither get_level() nor get_chapter_number() "
+                    "may be None for the given heading"
+                )
+            )
             # each chapter has its own sections, so if new chapter, reset all
             # section counters
         if heading.get_chapter_number() != self.__lastchapter:
@@ -134,7 +150,7 @@ class ChapterNumberEnumerator:
             self.__lastchapter = heading.get_chapter_number()
         # increment received level
         if heading.get_level() > 1:
-            self.__registered[heading.get_level()-1] += 1
+            self.__registered[heading.get_level() - 1] += 1
             # all headings below level must be reset to 0 (e.g. 2.1.1 is
             # followed by 2.2 not 2.2.1)
             for index in range(heading.get_level(), len(self.__registered)):
@@ -148,7 +164,7 @@ class ChapterNumberEnumerator:
         while chapter_number and chapter_number[-1] == 0:
             chapter_number = chapter_number[:-1]
         # if chapter_number is empty, probably chapter 0, so insert the 0 back
-        return chapter_number if chapter_number  else [0]
+        return chapter_number if chapter_number else [0]
 
 
 class TocFormatter:
@@ -157,14 +173,18 @@ Take the ordered dict produced by HeadingIndexer() and transform it
 to a markdown file containing the formatted table of contents. With the
 specified path, the TocFormatter is able to fetch the configuration to format
 the TOC corrrectly."""
-    def __init__(self, index, path, file_extension='html'):
+
+    def __init__(self, index, path, file_extension="html"):
         self.__index = index
         self.__path = path
         c = config.ConfFactory()
         self.conf = c.get_conf_instance(path)
         self.__use_appendix_prefix = self.conf[MetaInfo.AppendixPrefix]
-        self.__headings = {HeadingType.APPENDIX : [], HeadingType.NORMAL : [],
-                HeadingType.PREFACE: []}
+        self.__headings = {
+            HeadingType.APPENDIX: [],
+            HeadingType.NORMAL: [],
+            HeadingType.PREFACE: [],
+        }
         if self.conf[MetaInfo.GenerateToc] == 1:
             self.build_index()
         self.__file_extension = file_extension
@@ -174,75 +194,105 @@ the TOC corrrectly."""
         mapping from heading type to a list of headings. The list of headings
         contains 1) chapter number, 2) heading and 3) path to the file. In short
         this method builds the tree of information required for the TOC."""
-        enumerators = {HeadingType.NORMAL: ChapterNumberEnumerator(),
-                HeadingType.APPENDIX: ChapterNumberEnumerator(),
-                HeadingType.PREFACE: ChapterNumberEnumerator()}
+        enumerators = {
+            HeadingType.NORMAL: ChapterNumberEnumerator(),
+            HeadingType.APPENDIX: ChapterNumberEnumerator(),
+            HeadingType.PREFACE: ChapterNumberEnumerator(),
+        }
         for path, headings in self.__index.items():
             path, file = os.path.split(path)
             # necessary for relative link
             directory_above = os.path.split(path)[-1]
             for heading in headings:
                 if heading.get_level() > self.conf[MetaInfo.TocDepth]:
-                    continue # skip headings above configured threshold
+                    continue  # skip headings above configured threshold
                 h_type = heading.get_type()
                 if not isinstance(h_type, HeadingType):
-                    raise TypeError(("Internal error: Heading %s has incorrect"
-                            " heading type %s\nFile: %s") % (heading.get_text(),
-                                type(h_type), os.path.join(directory_above, file)))
+                    raise TypeError(
+                        (
+                            "Internal error: Heading %s has incorrect"
+                            " heading type %s\nFile: %s"
+                        )
+                        % (
+                            heading.get_text(),
+                            type(h_type),
+                            os.path.join(directory_above, file),
+                        )
+                    )
                 if heading.is_numbered():
                     # only numbered headings are registered for numbering and
                     # included in the TOC
                     enumerators[h_type].register(heading)
-                    self.__headings[h_type].append((
+                    self.__headings[h_type].append(
+                        (
                             enumerators[h_type].get_heading_enumeration(),
-                            heading, os.path.join(directory_above, file)))
-
-
+                            heading,
+                            os.path.join(directory_above, file),
+                        )
+                    )
 
     def format(self):
         """Format all headings into a markdown page."""
         if self.conf[MetaInfo.GenerateToc] == 0:
-            return ''
+            return ""
         l10n = config.Translate()
         l10n.set_language(self.conf[MetaInfo.Language])
         _ = l10n.get_translation
-        title = _('table of contents').title() + ' - ' + \
-                self.conf[MetaInfo.LectureTitle]
-        output = ['%s\n' % title, '='*len(title), '\n\n']
+        title = (
+            _("table of contents").title() + " - " + self.conf[MetaInfo.LectureTitle]
+        )
+        output = ["%s\n" % title, "=" * len(title), "\n\n"]
+
         def add_entry(file_name, toc_entry):
             if os.path.exists(file_name) or os.path.exists(file_name.lower()):
                 output.append(toc_entry)
 
         # if manual title page exists, link to it
-        add_entry("titel.md", '[%s](titel.%s\n\n' % (_('title page').title(),
-                self.__file_extension))
+        add_entry(
+            "titel.md",
+            "[%s](titel.%s\n\n" % (_("title page").title(), self.__file_extension),
+        )
 
         if self.__headings[HeadingType.PREFACE]:
-            output += self.format_section(_('preface').title(),
-                    self.__headings[HeadingType.PREFACE])
+            output += self.format_section(
+                _("preface").title(), self.__headings[HeadingType.PREFACE]
+            )
 
         # include section title "chapters" if a preface exists
         output += self.format_section(
-                _('chapters').title() if self.__headings[HeadingType.PREFACE] else None,
-                self.__headings[HeadingType.NORMAL])
+            _("chapters").title() if self.__headings[HeadingType.PREFACE] else None,
+            self.__headings[HeadingType.NORMAL],
+        )
         if self.__headings[HeadingType.APPENDIX]:
-            title = (None if self.__use_appendix_prefix else _('appendix').title())
+            title = None if self.__use_appendix_prefix else _("appendix").title()
             output += self.format_section(title, self.__headings[HeadingType.APPENDIX])
-        output.append('\n\n')
+        output.append("\n\n")
 
-        add_entry('taktil.md', '[{}](taktil.{})\\\n'.format(
-                _('list of tactile graphics').capitalize(), self.__file_extension))
-        add_entry('copyright.md', '[{}](copyright.{})\\\n'.format(
-                _('copyright notice').capitalize(), self.__file_extension))
+        add_entry(
+            "taktil.md",
+            "[{}](taktil.{})\\\n".format(
+                _("list of tactile graphics").capitalize(), self.__file_extension
+            ),
+        )
+        add_entry(
+            "copyright.md",
+            "[{}](copyright.{})\\\n".format(
+                _("copyright notice").capitalize(), self.__file_extension
+            ),
+        )
 
-        if output[-1].endswith('\\\n'): # strip \\ from last line
-            output[-1] = output[-1][:-2] + '\n'
+        if output[-1].endswith("\\\n"):  # strip \\ from last line
+            output[-1] = output[-1][:-2] + "\n"
 
         # include info.md, if it exists
-        add_entry("info.md", ('\n\n* * * * *\n\n[{}](info.{})\n').format(
+        add_entry(
+            "info.md",
+            ("\n\n* * * * *\n\n[{}](info.{})\n").format(
                 _("remarks about the accessible version").capitalize(),
-                self.__file_extension))
-        return ''.join(output) + '\n'
+                self.__file_extension,
+            ),
+        )
+        return "".join(output) + "\n"
 
     def format_section(self, title, headings):
         """Format a section of the table of contents. Sections are i.e. appendix
@@ -250,35 +300,41 @@ the TOC corrrectly."""
         Returned is a list of chunks which can be joined to a string."""
         chunks = []
         if title:
-            chunks = [title, '\n', '-' * len(title), '\n\n']
+            chunks = [title, "\n", "-" * len(title), "\n\n"]
         for index, (chapter_number, heading, path) in enumerate(headings):
-            chunks.append('\n%s' % self.__heading2toclink(chapter_number,
-                heading, path))
-            if index != len(headings)-1:
-                chunks.append('\\')
-        chunks.append('\n\n')
+            chunks.append(
+                "\n%s" % self.__heading2toclink(chapter_number, heading, path)
+            )
+            if index != len(headings) - 1:
+                chunks.append("\\")
+        chunks.append("\n\n")
         return chunks
 
     def __heading2toclink(self, chapter_number, heading, path):
         """Convert a heading to a link as required in a TOC.
         The enumerator object must provide a method called format_chap_number
         yielding the formatted chapter number."""
-        prefix = ''
+        prefix = ""
         if self.__use_appendix_prefix and heading.get_type() == HeadingType.APPENDIX:
-            prefix = 'A.'
-        path = path.replace('.md', '.' + self.__file_extension)
+            prefix = "A."
+        path = path.replace(".md", "." + self.__file_extension)
         # replace \ through / on windows:
-        if '\\' in path:
-            path = path.replace('\\', '/')
+        if "\\" in path:
+            path = path.replace("\\", "/")
 
         if heading.is_numbered():
             # when heading is numbered return it with number
-            return "[{}{} {}]({}#{})".format(prefix,
-                ".".join(map(str, chapter_number)), # (int, int...) -> str
-                heading.get_text(), path, heading.get_id())
+            return "[{}{} {}]({}#{})".format(
+                prefix,
+                ".".join(map(str, chapter_number)),  # (int, int...) -> str
+                heading.get_text(),
+                path,
+                heading.get_id(),
+            )
 
         # unnumbered headings don't have their number, so space is used only
         # if prefix is used
         space = " " if prefix else ""
-        return "[{}{}{}]({}#{})".format(prefix, space, heading.get_text(),
-                                        path, heading.get_id())
+        return "[{}{}{}]({}#{})".format(
+            prefix, space, heading.get_text(), path, heading.get_id()
+        )

--- a/README.md
+++ b/README.md
@@ -82,3 +82,15 @@ two-letter codes given by [ISO-639-1](https://en.wikipedia.org/wiki/List_of_ISO_
 
 For generation, you can use the e.g. the [msgfmt script]
 (http://refspecs.linuxbase.org/LSB_3.0.0/LSB-PDA/LSB-PDA/msgfmt.html)
+
+
+Development
+-----------
+
+### Code Style
+
+The source code is auto-formatted using the [black code
+formatter](https://github.com/psf/black).
+
+Before committing code changes, install it via ``pip install -U black`` and run ``black
+.`` in the repository's root to ensure everything is formatted in a consistent manner.

--- a/installer/build_windows_installer.py
+++ b/installer/build_windows_installer.py
@@ -19,7 +19,7 @@ import shutil
 import subprocess
 import sys
 
-sys.path.insert(0, os.path.abspath('..')) # insert directory above as first path
+sys.path.insert(0, os.path.abspath(".."))  # insert directory above as first path
 
 PANDOC_INSTALLER_URL = "https://github.com/jgm/pandoc/releases/download/2.7.3/pandoc-2.7.3-windows-x86_64.zip"
 
@@ -40,10 +40,10 @@ def subprocess_call(cmd, other_dir=None):
 
 class SetUp:
     """Check and retrieve build dependencies."""
+
     def __init__(self):
-        self.needs_wine = (True if not sys.platform.startswith('win') else
-                False)
-        self.python_command = ('wine python' if self.needs_wine else 'python')
+        self.needs_wine = True if not sys.platform.startswith("win") else False
+        self.python_command = "wine python" if self.needs_wine else "python"
 
     def check_for_command(self, cmd, debian_pkg, install_otherwise, silent=False):
         """Check whether given command exists and give instruction how to
@@ -55,97 +55,118 @@ class SetUp:
             if silent:
                 return False
             else:
-                print("`%s` not installed, which is required for building the Windows installer." % cmd)
-                if shutil.which('dpkg'):
+                print(
+                    "`%s` not installed, which is required for building the Windows installer."
+                    % cmd
+                )
+                if shutil.which("dpkg"):
                     print("  Install it using `sudo apt-get install %s`." % debian_pkg)
                 else:
                     print("  " + install_otherwise)
                 sys.exit(2)
 
-
     def check_for_module(self, module):
         """Check whether a library exists."""
-        command_prefix = ('wine ' if self.needs_wine else '')
-        module_found = os.system('%s -c "import %s"' % \
-                (self.python_command, module)) == 0
+        command_prefix = "wine " if self.needs_wine else ""
+        module_found = (
+            os.system('%s -c "import %s"' % (self.python_command, module)) == 0
+        )
         if not module_found:
-            print("%s missing, install using `%spip install %s`" % (
-                module, command_prefix, module))
+            print(
+                "%s missing, install using `%spip install %s`"
+                % (module, command_prefix, module)
+            )
             sys.exit(10)
 
     def detect_build_dependencies(self):
         if self.needs_wine:
-            self.check_for_command('wine', 'wine64', 'Install it from https://www.winehq.org/download')
+            self.check_for_command(
+                "wine", "wine64", "Install it from https://www.winehq.org/download"
+            )
             # detect python; -h switch is used to notprint output
-            if os.system('wine python -h 2>&1 > /dev/null'):
+            if os.system("wine python -h 2>&1 > /dev/null"):
                 # if command python3 not found, try python
-                print("Python not installed, install it in wine using ?`wine msiexec /i <msi-name>`")
+                print(
+                    "Python not installed, install it in wine using ?`wine msiexec /i <msi-name>`"
+                )
         else:
-            self.check_for_command('python', 'python3', 'Install it from https://www.winehq.org/download')
+            self.check_for_command(
+                "python", "python3", "Install it from https://www.winehq.org/download"
+            )
 
         import re
+
         # detect python version
-        proc = subprocess.Popen(self.python_command.split(' ') + ['--version'],
-                    stdout=subprocess.PIPE)
+        proc = subprocess.Popen(
+            self.python_command.split(" ") + ["--version"], stdout=subprocess.PIPE
+        )
         data = proc.communicate()[0].decode(sys.getdefaultencoding())
         if proc.wait():
-            print('error while retrieving python version: ', repr(data))
+            print("error while retrieving python version: ", repr(data))
             sys.exit(3)
-        pyversion = re.search(r'.*ython.*\s+(3\.\d+).*', data)
+        pyversion = re.search(r".*ython.*\s+(3\.\d+).*", data)
         if pyversion:
             pyversion = pyversion.groups()[0]
-            if not pyversion.startswith('3'):
-                print("Python version >= 3.2 required, found %s" % pyversion.groups()[0])
+            if not pyversion.startswith("3"):
+                print(
+                    "Python version >= 3.2 required, found %s" % pyversion.groups()[0]
+                )
         else:
             print("Python version >= 3.2 required.")
 
         # test for pyinstaller
-        self.check_for_command('pyinstaller', 'pyinstaller', 'Please run'\
-                                'pip install pyinstaller')
-        self.check_for_module('pandocfilters')
+        self.check_for_command(
+            "pyinstaller", "pyinstaller", "Please run" "pip install pyinstaller"
+        )
+        self.check_for_module("pandocfilters")
         # check for nsis generator
-        self.check_for_command('makensis', 'nsis',
-                "Please install it from http://nsis.sourceforge.net/Download.")
-        self.check_for_command('7z', 'p7zip-full',
-                'Please install it from http://7-zip.org')
-
+        self.check_for_command(
+            "makensis",
+            "nsis",
+            "Please install it from http://nsis.sourceforge.net/Download.",
+        )
+        self.check_for_command(
+            "7z", "p7zip-full", "Please install it from http://7-zip.org"
+        )
 
     def retrieve_dependencies(self):
         """Check whether all dependencies have been installed and downloaded."""
-        #pylint: disable=unused-variable,multiple-imports
+        # pylint: disable=unused-variable,multiple-imports
         # fetch gladtex
         os.mkdir(BUILD_DIRECTORY)
         import io, urllib.request, zipfile
+
         # fetch pandoc installer, extract pandoc.exe (is a static binary)
-        tmp = os.path.join(BUILD_DIRECTORY, 'tmp.pandoc')
+        tmp = os.path.join(BUILD_DIRECTORY, "tmp.pandoc")
         os.mkdir(tmp)
         print("Downloading", PANDOC_INSTALLER_URL)
         with urllib.request.urlopen(PANDOC_INSTALLER_URL) as u:
-            with open(os.path.join(tmp, 'x.zip'), 'wb') as f:
+            with open(os.path.join(tmp, "x.zip"), "wb") as f:
                 f.write(u.read())
         os.chdir(tmp)
-        if not shutil.which('7z'):
-            subprocess_call('7z x x.zip')
+        if not shutil.which("7z"):
+            subprocess_call("7z x x.zip")
         else:
-            subprocess_call('7z x x.zip')
-        subdir = os.listdir('.')[0] # unzips with subdirectory
+            subprocess_call("7z x x.zip")
+        subdir = os.listdir(".")[0]  # unzips with subdirectory
         if not os.path.isdir(subdir):
             raise OSError("Pandoc zip file layout changed, please fix this script.")
-        os.rename(os.path.join(subdir, 'pandoc.exe'),
-                os.path.join('..', 'pandoc.exe'))
+        os.rename(os.path.join(subdir, "pandoc.exe"), os.path.join("..", "pandoc.exe"))
         os.chdir("..")
-        shutil.rmtree(os.path.basename(tmp)) # remove pandoc's temp directory
+        shutil.rmtree(os.path.basename(tmp))  # remove pandoc's temp directory
         os.chdir("..")
 
 
 def clean():
     """Remove build directory."""
-    if not os.path.basename(os.getcwd()) == 'installer':
-        raise ValueError("BUG, expected to be in directory `installer`, but am in " + os.getcwd())
+    if not os.path.basename(os.getcwd()) == "installer":
+        raise ValueError(
+            "BUG, expected to be in directory `installer`, but am in " + os.getcwd()
+        )
     if os.path.exists(BUILD_DIRECTORY):
         shutil.rmtree(BUILD_DIRECTORY)
-    if os.path.exists(os.path.join('..', 'dist')):
-        shutil.rmtree(os.path.join('..', 'dist'))
+    if os.path.exists(os.path.join("..", "dist")):
+        shutil.rmtree(os.path.join("..", "dist"))
 
 
 def get_size(directory):
@@ -155,8 +176,7 @@ def get_size(directory):
     for path, _, files in os.walk(directory):
         for file in files:
             size += os.path.getsize(os.path.join(path, file))
-    return size / 1024 # bytes -> kB
-
+    return size / 1024  # bytes -> kB
 
 
 def update_installer_info(filename, version, total_size_kb):
@@ -166,17 +186,17 @@ def update_installer_info(filename, version, total_size_kb):
     data = []
     with open(filename, encoding="utf-8") as file:
         for line in file:
-            if '!define VERSIONMAJOR' in line:
-                line = '!define VERSIONMAJOR %d\n' % vlist[0]
-            elif '!define VERSIONMINOR' in line:
-                line = '!define VERSIONMINOR %d\n' % vlist[1]
-            elif '!define VERSIONBUILD' in line:
-                line = '!define VERSIONBUILD %d\n' % vlist[2]
-            elif '!define INSTALLSIZE' in line:
-                line = '!define INSTALLSIZE %d\n' % total_size_kb
+            if "!define VERSIONMAJOR" in line:
+                line = "!define VERSIONMAJOR %d\n" % vlist[0]
+            elif "!define VERSIONMINOR" in line:
+                line = "!define VERSIONMINOR %d\n" % vlist[1]
+            elif "!define VERSIONBUILD" in line:
+                line = "!define VERSIONBUILD %d\n" % vlist[2]
+            elif "!define INSTALLSIZE" in line:
+                line = "!define INSTALLSIZE %d\n" % total_size_kb
             # else: keep line
             data.append(line)
-    with open(filename, 'w', encoding="utf-8") as file:
+    with open(filename, "w", encoding="utf-8") as file:
         for line in data:
             file.write(line)
 
@@ -185,14 +205,16 @@ def compile_scripts(command, target):
     """Compile matuc using py2exe. Cross-compilation is determined by
     `python_command` (either 'python' or 'wine python')."""
     installer_src = path.dirname(path.abspath(__file__))
-    mod_path = path.join(path.dirname(installer_src), 'MAGSBS')
+    mod_path = path.join(path.dirname(installer_src), "MAGSBS")
     import gleetex  # required for getting path to gleetex module
 
-    for script in ['matuc.py', 'matuc_js.py']:
-        subprocess_call(f'pyinstaller --clean -d all MAGSBS{os.sep}{script} --onefile  --distpath installer{os.sep}{target} '\
-                  f'--paths {os.path.dirname(os.path.dirname(gleetex.__file__))} '\
-                  '--hidden-import=gleetex --additional-hooks-dir=.',
-                   other_dir=path.abspath('..'))
+    for script in ["matuc.py", "matuc_js.py"]:
+        subprocess_call(
+            f"pyinstaller --clean -d all MAGSBS{os.sep}{script} --onefile  --distpath installer{os.sep}{target} "
+            f"--paths {os.path.dirname(os.path.dirname(gleetex.__file__))} "
+            "--hidden-import=gleetex --additional-hooks-dir=.",
+            other_dir=path.abspath(".."),
+        )
 
 
 def build_installer():
@@ -200,33 +222,32 @@ def build_installer():
     # move a few files like e.g. README to distribution; MAGSBS and matuc_impl are
     # required, since py2exe doesn't include them properly
     target = lambda x: os.path.join(BUILD_DIRECTORY, x)
-    shutil.copytree(os.path.join('..', 'MAGSBS'), target('MAGSBS'))
-    shutil.copyfile(os.path.join('..', 'COPYING'), target('COPYING.txt'))
-    shutil.copyfile(os.path.join('..', 'README.md'), target('README.md'))
+    shutil.copytree(os.path.join("..", "MAGSBS"), target("MAGSBS"))
+    shutil.copyfile(os.path.join("..", "COPYING"), target("COPYING.txt"))
+    shutil.copyfile(os.path.join("..", "README.md"), target("README.md"))
     # make text files readable for Windows users
     os.chdir(BUILD_DIRECTORY)
-    if shutil.which('flip'):
-        os.system('flip -bm COPYING.txt')
-    os.chdir('..')
-
-
+    if shutil.which("flip"):
+        os.system("flip -bm COPYING.txt")
+    os.chdir("..")
 
     # move all files from BUILD_DIRECTORY to a subdirectory; this way a
     # temporary .nsis-file can be used
-    os.rename(BUILD_DIRECTORY, 'binary')
+    os.rename(BUILD_DIRECTORY, "binary")
     os.mkdir(BUILD_DIRECTORY)
-    os.rename('binary', os.path.join(BUILD_DIRECTORY, 'binary'))
+    os.rename("binary", os.path.join(BUILD_DIRECTORY, "binary"))
 
     # copy matuc.nsi and *.nsh to build/
-    shutil.copy('EnvVarUpdate.nsh', os.path.join(BUILD_DIRECTORY,
-        'EnvVarUpdate.nsh'))
-    shutil.copy('matuc.nsi', os.path.join(BUILD_DIRECTORY, 'matuc.nsi'))
+    shutil.copy("EnvVarUpdate.nsh", os.path.join(BUILD_DIRECTORY, "EnvVarUpdate.nsh"))
+    shutil.copy("matuc.nsi", os.path.join(BUILD_DIRECTORY, "matuc.nsi"))
 
-    #pylint: disable=import-error
+    # pylint: disable=import-error
     # update installer version number and size
     from MAGSBS.config import VERSION
-    update_installer_info(os.path.join(BUILD_DIRECTORY, 'matuc.nsi'), VERSION,
-            get_size(BUILD_DIRECTORY))
+
+    update_installer_info(
+        os.path.join(BUILD_DIRECTORY, "matuc.nsi"), VERSION, get_size(BUILD_DIRECTORY)
+    )
     # remove existing binary installer
     out_file = "matuc-installer-" + str(VERSION) + ".exe"
     if os.path.exists(out_file):
@@ -238,13 +259,15 @@ def build_installer():
     if shutil.which("chmod"):
         os.system("chmod a+r " + out_file)
 
+
 def main():
-    clean() # clean up previous build files
+    clean()  # clean up previous build files
     st = SetUp()
     st.detect_build_dependencies()
     st.retrieve_dependencies()
     compile_scripts(st.python_command, BUILD_DIRECTORY)
     build_installer()
     clean()
+
 
 main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.black]
+line-length = 88
+target-version = ['py36']

--- a/setup.py
+++ b/setup.py
@@ -12,9 +12,10 @@ from setuptools.command.install import install
 
 from MAGSBS.config import VERSION
 
-BUILD_DIR = 'build'
-POT_FILE = 'matuc.pot'
-mo_base = lambda lang: os.path.join(BUILD_DIR, 'mo', lang, 'LC_MESSAGES')
+BUILD_DIR = "build"
+POT_FILE = "matuc.pot"
+mo_base = lambda lang: os.path.join(BUILD_DIR, "mo", lang, "LC_MESSAGES")
+
 
 def shell(cmd, hint=None):
     ret = os.system(cmd)
@@ -24,28 +25,33 @@ def shell(cmd, hint=None):
             print(hint)
         sys.exit(ret)
 
+
 def mkmo(podir, pofile):
     outpath = mo_base(os.path.splitext(pofile)[0])
     if os.path.exists(outpath):
         shutil.rmtree(outpath)
     os.makedirs(outpath)
     inpath = os.path.join(podir, pofile)
-    shell("msgfmt %s -o %s%s%s.mo" % (inpath, outpath, os.sep, 'matuc'))
+    shell("msgfmt %s -o %s%s%s.mo" % (inpath, outpath, os.sep, "matuc"))
+
 
 class I18nBuild(build):
     """Build gettext locale files and install them appropriately."""
+
     user_options = build.user_options
+
     def run(self, *args):
-        for pofile in os.listdir('po'):
+        for pofile in os.listdir("po"):
             # ~-files are known to cause issues, delete them
-            if pofile.endswith('~'):
-                os.remove(os.path.join('po', pofile))
-            elif pofile.endswith('po'): # only convert .po files
-                mkmo('po', pofile)
+            if pofile.endswith("~"):
+                os.remove(os.path.join("po", pofile))
+            elif pofile.endswith("po"):  # only convert .po files
+                mkmo("po", pofile)
         build.run(self, *args)
 
-#pylint: disable=protected-access
-#pylint: disable=inconsistent-return-statements
+
+# pylint: disable=protected-access
+# pylint: disable=inconsistent-return-statements
 def locale_destdir():
     """Find best suitable directory for locales."""
     loc_dirs = [gettext._default_localedir]
@@ -53,10 +59,14 @@ def locale_destdir():
         loc_dirs += ["/usr/share/locale", "/usr/local/share/locale"]
     elif sys.platform == "win32":
         # default installer place
-        loc_dirs.append(os.path.join(os.getenv('ProgramData'), "matuc",
-                "locale"))
-    loc_dirs.append(os.path.join(os.path.dirname(os.path.dirname(
-                    os.path.abspath(sys.argv[0]))), 'share', 'locale'))
+        loc_dirs.append(os.path.join(os.getenv("ProgramData"), "matuc", "locale"))
+    loc_dirs.append(
+        os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(sys.argv[0]))),
+            "share",
+            "locale",
+        )
+    )
 
     dir_with_no_perms = None
     for directory in loc_dirs:
@@ -64,16 +74,18 @@ def locale_destdir():
             if os.access(directory, os.W_OK):
                 return directory
             dir_with_no_perms = directory
-        else: # doesn't exist, but maybe a parent?
+        else:  # doesn't exist, but maybe a parent?
             dirpath = directory[:]
             while dirpath and not os.path.exists(dirpath):
                 dirpath = os.path.dirname(dirpath)
             if dirpath and os.access(dirpath, os.W_OK):
                 return directory
     if dir_with_no_perms:
-        print("Insufficient rights to install translations (.mo) to " +
-                dir_with_no_perms)
+        print(
+            "Insufficient rights to install translations (.mo) to " + dir_with_no_perms
+        )
         sys.exit(81)
+
 
 class I18nGeneration(Command):
     description = "Create/update po/pot translation files"
@@ -86,62 +98,66 @@ class I18nGeneration(Command):
         pass
 
     def run(self):
-        files = (shlex.quote(os.path.join(dname, file))
-                for dname, _d, files in os.walk('MAGSBS') for file in files
-                if file.endswith('.py') and not 'build' in dname
-                    and not 'setup' in file and not 'test' in dname)
-        create_pot = not os.path.exists('matuc.pot')
+        files = (
+            shlex.quote(os.path.join(dname, file))
+            for dname, _d, files in os.walk("MAGSBS")
+            for file in files
+            if file.endswith(".py")
+            and not "build" in dname
+            and not "setup" in file
+            and not "test" in dname
+        )
+        create_pot = not os.path.exists("matuc.pot")
         if not create_pot:
             # query last modification time of py source files
-            matuc_mtime = os.path.getmtime('matuc.pot')
+            matuc_mtime = os.path.getmtime("matuc.pot")
             if any(os.path.getmtime(p) > matuc_mtime for p in files):
                 create_pot = True
         if create_pot:
             print("Extracting translatable strings...")
-            pygettext = ('pygettext3' if shutil.which('pygettext3')
-                    else 'pygettext')
-            shell(f'{pygettext} --keyword=_ --output=matuc.pot %s' \
-                    % ' '.join(files))
+            pygettext = "pygettext3" if shutil.which("pygettext3") else "pygettext"
+            shell(f"{pygettext} --keyword=_ --output=matuc.pot %s" % " ".join(files))
         # merge new strings and old translations
-        for lang_po in os.listdir('po'):
-            shell("msgmerge -F -U %s matuc.pot" % os.path.join('po', lang_po))
+        for lang_po in os.listdir("po"):
+            shell("msgmerge -F -U %s matuc.pot" % os.path.join("po", lang_po))
+
 
 class I18nInstall(install):
     """Install compiled .mo files."""
+
     user_options = install.user_options
+
     def run(self):
         install.run(self)
-        for lang in os.listdir(os.path.join(BUILD_DIR, 'mo')):
-            destdir = os.path.join(locale_destdir(), lang, 'LC_MESSAGES')
+        for lang in os.listdir(os.path.join(BUILD_DIR, "mo")):
+            destdir = os.path.join(locale_destdir(), lang, "LC_MESSAGES")
             if not os.path.exists(destdir):
                 os.makedirs(destdir)
-            src_mo = os.path.join(BUILD_DIR, 'mo', lang, 'LC_MESSAGES', 'matuc.mo')
+            src_mo = os.path.join(BUILD_DIR, "mo", lang, "LC_MESSAGES", "matuc.mo")
             print(f"Installing {src_mo} to {destdir}")
             shutil.copy(src_mo, destdir)
+
 
 setuptools.setup(
     author="Sebastian Humenda, Jens Voegler",
     cmdclass={
-        'build_i18n': I18nGeneration,
-        'build_py': I18nBuild,
-        'install': I18nInstall
-        },
+        "build_i18n": I18nGeneration,
+        "build_py": I18nBuild,
+        "install": I18nInstall,
+    },
     description="MAGSBS - MarkDown AG SBS module",
     entry_points={
-       "console_scripts": [
-           "matuc = MAGSBS.matuc:main",
-           "matuc_js = MAGSBS.matuc_js:main",
+        "console_scripts": [
+            "matuc = MAGSBS.matuc:main",
+            "matuc_js = MAGSBS.matuc_js:main",
         ],
     },
-    install_requires=[
-        "pandocfilters >= 1.4.2",
-        "gladtex       >= 3.1"
-    ],
+    install_requires=["pandocfilters >= 1.4.2", "gladtex       >= 3.1"],
     include_package_data=True,
     license="LGPL",
     name="MAGSBS-matuc",
     packages=setuptools.find_packages("."),
     url="https://github.com/TUD-INF-IAI-MCI/AGSBS-infrastructure",
     version=str(VERSION),
-    zip_safe=True
+    zip_safe=True,
 )

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -5,15 +5,17 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import MAGSBS
 import unittest, unittest.mock
+
 # Running tests will load the built-in MAGSBS localisation support which is not
 # available during test runtime. Hence it's better mocked out. For the few rare
 # cases where the warning registry is under test, the mock can be added using a
 # patch to the test function.
 import MAGSBS.common
 
-with unittest.mock.patch('MAGSBS.common.WarningRegistry'):
+with unittest.mock.patch("MAGSBS.common.WarningRegistry"):
     MAGSBS.common.setup_i18n()
     import unittest
-    sys.argv.append('discover')
-    sys.argv.append('tests')
+
+    sys.argv.append("discover")
+    sys.argv.append("tests")
     unittest.TestProgram(module=None)

--- a/tests/quality_assurance/testBrokenImageLinksAreDetected.py
+++ b/tests/quality_assurance/testBrokenImageLinksAreDetected.py
@@ -1,8 +1,9 @@
-#pylint: disable=too-many-public-methods,import-error,too-few-public-methods,missing-docstring,unused-variable,multiple-imports
+# pylint: disable=too-many-public-methods,import-error,too-few-public-methods,missing-docstring,unused-variable,multiple-imports
 import unittest
 
 from MAGSBS.quality_assurance.markdown import BrokenImageLinksAreDetected
 from MAGSBS.quality_assurance.meta import ErrorMessage
+
 
 def checker(text):
     """Shorthand to call checker under test."""
@@ -16,37 +17,71 @@ def is_error(obj):
 
 class TestBrokenImageLinksAreDetected(unittest.TestCase):
     def test_forgotten_brackets_are_recognized(self):
-        missing_left = '!bla](jo)'
-        missing_right = '![foo(jo)'
-        self.assertTrue(is_error(checker(missing_left)), "Expected an error, got %s" % checker(missing_left))
-        self.assertTrue(is_error(checker(missing_right)), "Expected an error, got %s" % checker(missing_left))
+        missing_left = "!bla](jo)"
+        missing_right = "![foo(jo)"
+        self.assertTrue(
+            is_error(checker(missing_left)),
+            "Expected an error, got %s" % checker(missing_left),
+        )
+        self.assertTrue(
+            is_error(checker(missing_right)),
+            "Expected an error, got %s" % checker(missing_left),
+        )
+
     def test_that_missing_parenthesis_are_detected(self):
-        missing_left = '![jo]bilder.md)'
-        missing_right = '![jo](booo.md'
-        self.assertTrue(is_error(checker(missing_left)),
-                "expected type error, got %s " % type(checker(missing_left)))
-        self.assertTrue(is_error(checker(missing_right)),
-                "expected type error, got %s " % type(checker(missing_right)))
+        missing_left = "![jo]bilder.md)"
+        missing_right = "![jo](booo.md"
+        self.assertTrue(
+            is_error(checker(missing_left)),
+            "expected type error, got %s " % type(checker(missing_left)),
+        )
+        self.assertTrue(
+            is_error(checker(missing_right)),
+            "expected type error, got %s " % type(checker(missing_right)),
+        )
 
     def test_that_valid_images_is_ok(self):
-        simple = '![jo](bilder.md)'
-        self.assertFalse(is_error(checker(simple)), "Did not expect error, got it anyway: %s" % checker(simple))
-        self.assertFalse(is_error(checker('')), "Did not expect error, got it anyway: %s" % checker(simple))
-        self.assertFalse(is_error(checker('some_text')), "Did not expect error, got it anyway: %s" % checker(simple))
+        simple = "![jo](bilder.md)"
+        self.assertFalse(
+            is_error(checker(simple)),
+            "Did not expect error, got it anyway: %s" % checker(simple),
+        )
+        self.assertFalse(
+            is_error(checker("")),
+            "Did not expect error, got it anyway: %s" % checker(simple),
+        )
+        self.assertFalse(
+            is_error(checker("some_text")),
+            "Did not expect error, got it anyway: %s" % checker(simple),
+        )
 
     def test_that_trailing_and_leading_text_is_ok(self):
-        trailing = '![foo](bar) stuff'
-        leading = 'jojo ![foo](bilder.jpg)'
-        self.assertTrue(not is_error(checker(trailing)), "Did not expect error, got it anyway: %s" % checker(trailing))
-        self.assertTrue(not is_error(checker(leading)), "Did not expect error, got it anyway: %s" % checker(leading))
+        trailing = "![foo](bar) stuff"
+        leading = "jojo ![foo](bilder.jpg)"
+        self.assertTrue(
+            not is_error(checker(trailing)),
+            "Did not expect error, got it anyway: %s" % checker(trailing),
+        )
+        self.assertTrue(
+            not is_error(checker(leading)),
+            "Did not expect error, got it anyway: %s" % checker(leading),
+        )
 
     def test_that_indentation_is_ok(self):
-        indented_s = '    ![foo](jpg)'
-        indented_t = '\t![foo](jpg)'
-        self.assertFalse(is_error(checker(indented_s)), "Did not expect error, got it anyway: %s" % checker(indented_s))
-        self.assertFalse(is_error(checker(indented_t)), "Did not expect error, got it anyway: %s" % checker(indented_t))
+        indented_s = "    ![foo](jpg)"
+        indented_t = "\t![foo](jpg)"
+        self.assertFalse(
+            is_error(checker(indented_s)),
+            "Did not expect error, got it anyway: %s" % checker(indented_s),
+        )
+        self.assertFalse(
+            is_error(checker(indented_t)),
+            "Did not expect error, got it anyway: %s" % checker(indented_t),
+        )
 
     def test_that_nested_structure_work(self):
-        nested = '[![this one is all right](bilder/bild.jpg)](some.html#file)'
-        self.assertFalse(is_error(checker(nested)), "Did not expect error, got it anyway: %s" % checker(nested))
-
+        nested = "[![this one is all right](bilder/bild.jpg)](some.html#file)"
+        self.assertFalse(
+            is_error(checker(nested)),
+            "Did not expect error, got it anyway: %s" % checker(nested),
+        )

--- a/tests/quality_assurance/testCasesSqueezedOnOneLine.py
+++ b/tests/quality_assurance/testCasesSqueezedOnOneLine.py
@@ -1,15 +1,17 @@
-#pylint: disable=too-many-public-methods,import-error,too-few-public-methods,missing-docstring,unused-variable,multiple-imports
+# pylint: disable=too-many-public-methods,import-error,too-few-public-methods,missing-docstring,unused-variable,multiple-imports
 import unittest
 from MAGSBS.quality_assurance import CasesSqueezedOnOneLine
 
+
 class testCasesSqueezedOnOneLine(unittest.TestCase):
     def test_that_errorneous_case_is_detected(self):
-        err = CasesSqueezedOnOneLine().worker({(1,1):
-            r"\begin{cases}a&b\\c&d\end{cases}"})
+        err = CasesSqueezedOnOneLine().worker(
+            {(1, 1): r"\begin{cases}a&b\\c&d\end{cases}"}
+        )
         self.assertTrue(err, "error expected, got %s" % repr(err))
-    
+
     def test_that_proper_case_environments_are_ignored(self):
-        err = CasesSqueezedOnOneLine().worker({(1,1):
-            "\\begin{cases}a&b\\\\\nc&d\\end{cases}"})
+        err = CasesSqueezedOnOneLine().worker(
+            {(1, 1): "\\begin{cases}a&b\\\\\nc&d\\end{cases}"}
+        )
         self.assertFalse(err, "Expected nothing, got " + repr(err))
-        

--- a/tests/quality_assurance/testDetectEmptyImageDescriptions.py
+++ b/tests/quality_assurance/testDetectEmptyImageDescriptions.py
@@ -1,4 +1,4 @@
-#pylint: disable=too-many-public-methods,import-error,too-few-public-methods,missing-docstring,unused-variable,multiple-imports
+# pylint: disable=too-many-public-methods,import-error,too-few-public-methods,missing-docstring,unused-variable,multiple-imports
 import os
 import random
 import shutil
@@ -7,6 +7,7 @@ import unittest
 
 import MAGSBS.quality_assurance.markdown as markdown
 from MAGSBS import datastructures
+
 
 def make_headings(**headings):
     """Transform {'path':[(1,2), (3, 4)]) into {'path' : [<heading_object>, ...]}, where
@@ -20,22 +21,23 @@ def make_headings(**headings):
     content."""
     proper_headings = {}
     for path, headings in headings.items():
-        if path.startswith('k'):
-            path = '{}/{}.md'.format(path, path[:3])
+        if path.startswith("k"):
+            path = "{}/{}.md".format(path, path[:3])
         else:
-            path = 'k01/%s.md' % path
+            path = "k01/%s.md" % path
         if isinstance(headings[0], str):
             if not os.path.exists(os.path.split(path)[0]):
                 os.mkdir(os.path.split(path)[0])
-            with open(path, 'w', encoding='utf-8') as f:
+            with open(path, "w", encoding="utf-8") as f:
                 f.write(headings.pop(0))
         proper_headings[path] = []
         for level, lnum in headings:
-            text = 'h%s%s' % (level, random.randint(1,999999999))
+            text = "h%s%s" % (level, random.randint(1, 999999999))
             h = datastructures.Heading(text, level)
             h.set_line_number(lnum)
             proper_headings[path].append(h)
     return proper_headings
+
 
 def check(headings):
     return markdown.DetectEmptyImageDescriptions().worker(headings)
@@ -52,43 +54,81 @@ class TestDetectEmptyImageDescriptions(unittest.TestCase):
         shutil.rmtree(self.tmp, ignore_errors=True)
 
     def test_that_empty_chapters_are_ignored(self):
-        h = make_headings(k01 = ['jojo\n=======\n\n## 99', (1,1), (4,1)])
+        h = make_headings(k01=["jojo\n=======\n\n## 99", (1, 1), (4, 1)])
         self.assertFalse(check(h))
 
     def test_that_images_with_description_are_ignored(self):
-        h = make_headings(bilder = ['# ok\n##ok II\n\ndesc\n\n## ok III\n\ndesc\n',
-            (1,1), (2,2), (2,6)])
+        h = make_headings(
+            bilder=[
+                "# ok\n##ok II\n\ndesc\n\n## ok III\n\ndesc\n",
+                (1, 1),
+                (2, 2),
+                (2, 6),
+            ]
+        )
         heading = check(h)
-        self.assertFalse(heading, ("expected that all descriptions got assigned "
-            "to headings, so no headings would be reported, but got heading from "
-            "line ") + str(heading.get_lnum() if heading else None))
+        self.assertFalse(
+            heading,
+            (
+                "expected that all descriptions got assigned "
+                "to headings, so no headings would be reported, but got heading from "
+                "line "
+            )
+            + str(heading.get_lnum() if heading else None),
+        )
 
     def test_that_missing_descriptions_at_end_of_file_detected(self):
-        h = make_headings(bilder = ['# ok\n##ok II\n\ndesc\n\n## ok III\n\n',
-            (1,1), (2,2), (2,6)])
+        h = make_headings(
+            bilder=["# ok\n##ok II\n\ndesc\n\n## ok III\n\n", (1, 1), (2, 2), (2, 6)]
+        )
         self.assertTrue(check(h))
 
     def test_that_missing_descriptions_detected_in_middle_of_file(self):
-        h = make_headings(bilder = ['# ok\n##ok II\n\ndesc\n\n## blub\n\n## ok III\n\ndesc',
-            (1,1), (2,2), (2,6), (2, 8)])
+        h = make_headings(
+            bilder=[
+                "# ok\n##ok II\n\ndesc\n\n## blub\n\n## ok III\n\ndesc",
+                (1, 1),
+                (2, 2),
+                (2, 6),
+                (2, 8),
+            ]
+        )
         self.assertTrue(check(h))
 
-    def test_that_empty_description_detected_even_if_multiple_headings_within_paragraph(self):
-        h = make_headings(bilder = ['# yup\n\n## abc\n## def\n', (1,1), (2,3),
-            (2,4)])
+    def test_that_empty_description_detected_even_if_multiple_headings_within_paragraph(
+        self,
+    ):
+        h = make_headings(bilder=["# yup\n\n## abc\n## def\n", (1, 1), (2, 3), (2, 4)])
         self.assertTrue(check(h))
 
     def test_that_underline_of_headings_ignored(self):
-        h = make_headings(bilder = ['yup\n====\n\n## abc\n\nup\n\n## def\n\nkk\n',
-            (1,2), (2,4), (2,8)])
+        h = make_headings(
+            bilder=[
+                "yup\n====\n\n## abc\n\nup\n\n## def\n\nkk\n",
+                (1, 2),
+                (2, 4),
+                (2, 8),
+            ]
+        )
         err = check(h)
-        self.assertFalse(err, ("expected no image description to be detected as empty"
-            ", but found one at line %s") % (err.get_lnum() if err else repr(err)))
-        h = make_headings(bilder = ['# yup\n\nabc\n--------\n\nup\n\ndef\n-------\n\n',
-            (1,2), (2,3), (2,8)])
+        self.assertFalse(
+            err,
+            (
+                "expected no image description to be detected as empty"
+                ", but found one at line %s"
+            )
+            % (err.get_lnum() if err else repr(err)),
+        )
+        h = make_headings(
+            bilder=[
+                "# yup\n\nabc\n--------\n\nup\n\ndef\n-------\n\n",
+                (1, 2),
+                (2, 3),
+                (2, 8),
+            ]
+        )
         self.assertTrue(check(h))
 
     def test_that_empty_image_descriptions_file_is_file_as_well(self):
-        h = make_headings(bilder = ['bla bla\nblub blub\ntricked tricked\n'])
+        h = make_headings(bilder=["bla bla\nblub blub\ntricked tricked\n"])
         self.assertFalse(check(h))
-

--- a/tests/quality_assurance/testDetectStrayingDollars.py
+++ b/tests/quality_assurance/testDetectStrayingDollars.py
@@ -1,8 +1,9 @@
-#pylint: disable=too-many-public-methods,import-error,too-few-public-methods,missing-docstring,unused-variable
+# pylint: disable=too-many-public-methods,import-error,too-few-public-methods,missing-docstring,unused-variable
 # absolute imports are fine: we're running test cases from the top directory
 import MAGSBS.quality_assurance.markdown as ma
 import MAGSBS.quality_assurance.meta as meta
 import unittest
+
 
 def check(line, lnum=1):
     checker = ma.DetectStrayingDollars()
@@ -34,7 +35,7 @@ class test_DetectStrayingDollars(unittest.TestCase):
         self.assertNotEqual(check(text), None)
 
     def test_that_escaped_dollars_are_ignored(self):
-        text = 'formula: $jo$ and \$ is ignored'
+        text = "formula: $jo$ and \$ is ignored"
         self.assertEqual(check(text), None)
 
     def test_that_prices_are_ignored(self):
@@ -42,7 +43,5 @@ class test_DetectStrayingDollars(unittest.TestCase):
         self.assertEqual(check(text), None)
 
     def test_that_straying_dollar_at_end_detected(self):
-        text = r'The formula is 3\cdot 2$'
+        text = r"The formula is 3\cdot 2$"
         self.assertNotEqual(check(text), None)
-    
-

--- a/tests/quality_assurance/testDisplayMathShouldNotBeInsideAParagraph.py
+++ b/tests/quality_assurance/testDisplayMathShouldNotBeInsideAParagraph.py
@@ -1,13 +1,16 @@
-#pylint: disable=too-many-public-methods,import-error,too-few-public-methods,missing-docstring,unused-variable,multiple-imports
+# pylint: disable=too-many-public-methods,import-error,too-few-public-methods,missing-docstring,unused-variable,multiple-imports
 import unittest
 from MAGSBS.quality_assurance import latex
 from MAGSBS.quality_assurance import meta
 
+
 def iserror(obj):
     return isinstance(obj, meta.ErrorMessage)
 
+
 def check(text):
     return latex.DisplayMathShouldNotBeUsedWithinAParagraph().check(1, text)
+
 
 class testDisplayMathShouldNotBeInsideAParagraph(unittest.TestCase):
     def test_error_is_not_triggered_for_correct_formulas(self):
@@ -28,4 +31,3 @@ class testDisplayMathShouldNotBeInsideAParagraph(unittest.TestCase):
 
     def test_that_multiple_displaymaths_are_detected(self):
         self.assertTrue(iserror(check("jo $$a$$ and $$b$$")))
-

--- a/tests/quality_assurance/testDoNotEmbeddHtml.py
+++ b/tests/quality_assurance/testDoNotEmbeddHtml.py
@@ -1,41 +1,42 @@
-#pylint: disable=too-many-public-methods,import-error,too-few-public-methods,missing-docstring,unused-variable,multiple-imports
+# pylint: disable=too-many-public-methods,import-error,too-few-public-methods,missing-docstring,unused-variable,multiple-imports
 import unittest
 
 import MAGSBS.quality_assurance
 
+
 def check(text):
     return MAGSBS.quality_assurance.DoNotEmbedHtml().check(1, text)
 
+
 class testDoNotEmbeddHtml(unittest.TestCase):
     def test_normal_text_does_not_trigger_error(self):
-        self.assertFalse(check('Dies ist < als das > hier.'))
+        self.assertFalse(check("Dies ist < als das > hier."))
 
     def test_that_lesser_and_greater_in_formula_are_ignored(self):
-        self.assertFalse(check('Ok: $f<a/b; b/c>d$'))
+        self.assertFalse(check("Ok: $f<a/b; b/c>d$"))
 
     def test_that_line_breaks_are_recognized(self):
-        self.assertTrue(check('<br>'))
-        self.assertTrue(check('<br/>'))
-        self.assertTrue(check('<br />'))
-        self.assertTrue(check('<BR />'))
+        self.assertTrue(check("<br>"))
+        self.assertTrue(check("<br/>"))
+        self.assertTrue(check("<br />"))
+        self.assertTrue(check("<BR />"))
 
     def test_that_div_and_span_are_ignored(self):
-        self.assertFalse(check('<div>foo</div>'))
-        self.assertFalse(check('<DIV>FOO</DIV>'))
+        self.assertFalse(check("<div>foo</div>"))
+        self.assertFalse(check("<DIV>FOO</DIV>"))
         self.assertFalse(check('<div class="foobar" attr="9">foo</div>'))
-        self.assertFalse(check('<span>foo</span>'))
-        self.assertFalse(check('<span>FOO</span>'))
+        self.assertFalse(check("<span>foo</span>"))
+        self.assertFalse(check("<span>FOO</span>"))
         self.assertFalse(check('<span class="foobar" attr="9">foo</span>'))
 
     def test_that_opening_and_closing_tags_are_recognized(self):
-        self.assertTrue(check('<body>foo</body>'))
+        self.assertTrue(check("<body>foo</body>"))
         self.assertTrue(check('<a id="foobar">whatever</a>'))
         self.assertTrue(check('<A id="foobar">whatever</A>'))
         self.assertTrue(check('<A id="foobar" >whatever</ A>'))
 
     def test_that_stand_alone_tags_are_recognized(self):
-        self.assertTrue(check('<p/>'))
-        self.assertTrue(check('<P/>'))
-        self.assertTrue(check('<p/ >'))
-        self.assertTrue(check('<p />'))
-
+        self.assertTrue(check("<p/>"))
+        self.assertTrue(check("<P/>"))
+        self.assertTrue(check("<p/ >"))
+        self.assertTrue(check("<p />"))

--- a/tests/quality_assurance/testFreeStandingFormulasShouldBeDisplaymath.py
+++ b/tests/quality_assurance/testFreeStandingFormulasShouldBeDisplaymath.py
@@ -1,37 +1,43 @@
-#pylint: disable=too-many-public-methods,import-error,too-few-public-methods,missing-docstring,unused-variable,multiple-imports
+# pylint: disable=too-many-public-methods,import-error,too-few-public-methods,missing-docstring,unused-variable,multiple-imports
 import unittest
 
 from MAGSBS.quality_assurance import latex
 
+
 def check(formula):
-    return latex.FreeStandingFormulasShouldBeDisplaymath().worker({1:
-        formula.split('\n')})
+    return latex.FreeStandingFormulasShouldBeDisplaymath().worker(
+        {1: formula.split("\n")}
+    )
+
 
 class testFormulasSpanningAParagraphShouldBeDisplayMath(unittest.TestCase):
     def test_that_normal_paragraphs_are_ignored(self):
-        result = check('bla\nblub\ndfdfkj')
-        self.assertFalse(result, "expected that normal text is ignored, but got " + repr(result))
+        result = check("bla\nblub\ndfdfkj")
+        self.assertFalse(
+            result, "expected that normal text is ignored, but got " + repr(result)
+        )
 
     def test_that_single_dollars_ignored(self):
-        for text in ['This is $6', '$ should rule', 'I need $']:
+        for text in ["This is $6", "$ should rule", "I need $"]:
             result = check(text)
-            self.assertFalse(result,
-                    "expected no error when checking {}, got {}".format(text, repr(result)))
+            self.assertFalse(
+                result,
+                "expected no error when checking {}, got {}".format(text, repr(result)),
+            )
 
     def test_that_display_math_not_detected_by_chance(self):
-        self.assertFalse(check('$$\\pi\\tau$$'))
+        self.assertFalse(check("$$\\pi\\tau$$"))
 
     def test_that_inline_maths_spanning_par_detected(self):
-        self.assertTrue(check('$ok this is rather lengthy$'))
+        self.assertTrue(check("$ok this is rather lengthy$"))
 
     def test_that_surrounding_spaces_dont_matter_and_still_trigger(self):
-        self.assertTrue(check('    $ok this is rather lengthy$    '))
-        self.assertTrue(check('\t$ok this is rather lengthy$\t'))
-        self.assertTrue(check('   $mr hard$'))
+        self.assertTrue(check("    $ok this is rather lengthy$    "))
+        self.assertTrue(check("\t$ok this is rather lengthy$\t"))
+        self.assertTrue(check("   $mr hard$"))
 
     def test_that_proper_inline_math_envs_dont_trigger(self):
-        self.assertFalse(check('\t$\\pi$ I do like.'))
+        self.assertFalse(check("\t$\\pi$ I do like."))
 
     def test_that_multiple_inline_maths_on_a_line_dont_trigger(self):
-        self.assertFalse(check('$abc$; we\'re tricking: $you$ '))
-        
+        self.assertFalse(check("$abc$; we're tricking: $you$ "))

--- a/tests/quality_assurance/testHyphensFromJustifiedTextWereRemoved.py
+++ b/tests/quality_assurance/testHyphensFromJustifiedTextWereRemoved.py
@@ -1,47 +1,48 @@
-#pylint: disable=too-many-public-methods,import-error,too-few-public-methods,missing-docstring,unused-variable,multiple-imports
+# pylint: disable=too-many-public-methods,import-error,too-few-public-methods,missing-docstring,unused-variable,multiple-imports
 import unittest
 from MAGSBS.quality_assurance.markdown import HyphensFromJustifiedTextWereRemoved
 from MAGSBS.quality_assurance.meta import ErrorMessage
+
 
 def checker(pars):
     c = HyphensFromJustifiedTextWereRemoved()
     return c.worker(pars)
 
+
 def str2par(string):
     """Convert string into paragraphs:
     {line_numer : [line1, line2, ...]}
     """
-    return {1 : string.split('\n')}
+    return {1: string.split("\n")}
 
 
 class TestHyphensFromJustifiedTextWereRemoved(unittest.TestCase):
     def test_that_normal_paragraph_is_ok(self):
-        par = str2par('This is a\nlot of text\ncausing no problems.')
+        par = str2par("This is a\nlot of text\ncausing no problems.")
         self.assertEqual(checker(par), None)
 
     def test_that_hyphen_within_paragraph_is_detected(self):
-        par = str2par('some text\nwhich is not too leng-\nthy at all.')
+        par = str2par("some text\nwhich is not too leng-\nthy at all.")
         self.assertTrue(isinstance(checker(par), ErrorMessage))
 
     def test_that_hyphens_at_beginning_of_par_detected(self):
-        par = str2par('This is a stupid al-\ngorithm which\n hopefully works.')
+        par = str2par("This is a stupid al-\ngorithm which\n hopefully works.")
         self.assertTrue(isinstance(checker(par), ErrorMessage))
 
     def test_that_hypehsns_at_end_of_paragraphs_are_all_right(self):
-        par = str2par('foo foo\nbar bar-')
+        par = str2par("foo foo\nbar bar-")
         self.assertEqual(checker(par), None)
 
     def test_that_tables_dont_trigger_error(self):
-        par = str2par('--- ----\na   b\nc   d\n--- ---')
+        par = str2par("--- ----\na   b\nc   d\n--- ---")
         self.assertEqual(checker(par), None)
 
     def test_that_hyphen_at_end_of_line_and_no_word_at_next_line_is_ignored(self):
-        par = str2par('foo bar-\n+-----+...')
+        par = str2par("foo bar-\n+-----+...")
         self.assertEqual(checker(par), None)
 
     def test_that_and_or_und_on_next_line_are_tolerated(self):
-        par = str2par('hard-\nand software')
+        par = str2par("hard-\nand software")
         self.assertEqual(checker(par), None)
-        par = str2par('Hard-\nund Software')
+        par = str2par("Hard-\nund Software")
         self.assertEqual(checker(par), None)
-

--- a/tests/quality_assurance/testLevelOneHeading.py
+++ b/tests/quality_assurance/testLevelOneHeading.py
@@ -1,4 +1,4 @@
-#pylint: disable=too-many-public-methods,import-error,too-few-public-methods,missing-docstring,unused-variable,multiple-imports
+# pylint: disable=too-many-public-methods,import-error,too-few-public-methods,missing-docstring,unused-variable,multiple-imports
 import unittest
 import random
 
@@ -14,35 +14,36 @@ def make_headings(**headings):
         bilder -> k01/bilder.md"""
     proper_headings = {}
     for path, headings in headings.items():
-        if path.startswith('k'):
-            path = '{0}/{0}.md'.format(path, path[:3])
+        if path.startswith("k"):
+            path = "{0}/{0}.md".format(path, path[:3])
         else:
-            path = 'k01/%s.md' % path
+            path = "k01/%s.md" % path
         proper_headings[path] = []
         for level in headings:
-            text = 'h%s%s' % (level, random.randint(1,999999999))
+            text = "h%s%s" % (level, random.randint(1, 999999999))
             h = datastructures.Heading(text, level)
             proper_headings[path].append(h)
     return proper_headings
 
+
 def check(headings):
     return LevelOneHeading().worker(headings)
 
+
 class TestLevelOneHeading(unittest.TestCase):
     def test_that_chapters_without_h1_dont_trigger(self):
-        headings = make_headings(k01 = [2,3,2,3,2,3,4,5,6])
+        headings = make_headings(k01=[2, 3, 2, 3, 2, 3, 4, 5, 6])
         self.assertFalse(check(headings))
 
     def test_that_directories_with_just_one_h1_heading_dont_trigger(self):
-        self.assertFalse(check(make_headings(k01 = [1,2,3,4,5,6])))
+        self.assertFalse(check(make_headings(k01=[1, 2, 3, 4, 5, 6])))
 
     def test_that_h1_in_image_file_is_ignored(self):
-        h = make_headings(k01 = [1,2,3,4,5,6], bilder = [1,2,3,2,3,2])
+        h = make_headings(k01=[1, 2, 3, 4, 5, 6], bilder=[1, 2, 3, 2, 3, 2])
         self.assertFalse(check(h))
 
     def test_that_two_h1_in_one_directory_trigger(self):
-        h = make_headings(k0101 = [1,2,3,4], k0102 = [1,2,3,4])
+        h = make_headings(k0101=[1, 2, 3, 4], k0102=[1, 2, 3, 4])
         self.assertTrue(check(h))
-        h = make_headings(k0101 = [1, 1, 2, 3])
+        h = make_headings(k0101=[1, 1, 2, 3])
         self.assertTrue(check(h))
-

--- a/tests/quality_assurance/testLinkChecker.py
+++ b/tests/quality_assurance/testLinkChecker.py
@@ -8,28 +8,43 @@ from MAGSBS.quality_assurance import linkchecker
 
 
 class TestLinkChecker(unittest.TestCase):
-
     @staticmethod
     def get_path(reference):
         parsed = urlparse(reference.link)
         return parsed.path
 
     def test_coupling_references(self):
-        reference_1 = Reference(Reference.Type.EXPLICIT, False,
-                                link="k01.html", identifier="1", line_number=1)
-        reference_2 = Reference(Reference.Type.IMPLICIT, False, identifier="2",
-                                line_number=2)
+        reference_1 = Reference(
+            Reference.Type.EXPLICIT,
+            False,
+            link="k01.html",
+            identifier="1",
+            line_number=1,
+        )
+        reference_2 = Reference(
+            Reference.Type.IMPLICIT, False, identifier="2", line_number=2
+        )
 
-        reference_expl_ok = Reference(Reference.Type.EXPLICIT, False,
-                                      identifier="2", link="k01.html")
-        reference_expl_nok = Reference(Reference.Type.EXPLICIT, False,
-                                       identifier="non-existing-link",
-                                       link="k01.html", line_number=8)
-        reference_impl_ok = Reference(Reference.Type.IMPLICIT, False,
-                                      identifier="1", link="k01.html",
-                                      line_number=10)
-        reference_impl_nok = Reference(Reference.Type.IMPLICIT, False,
-                                       identifier="incorrect", line_number=12)
+        reference_expl_ok = Reference(
+            Reference.Type.EXPLICIT, False, identifier="2", link="k01.html"
+        )
+        reference_expl_nok = Reference(
+            Reference.Type.EXPLICIT,
+            False,
+            identifier="non-existing-link",
+            link="k01.html",
+            line_number=8,
+        )
+        reference_impl_ok = Reference(
+            Reference.Type.IMPLICIT,
+            False,
+            identifier="1",
+            link="k01.html",
+            line_number=10,
+        )
+        reference_impl_nok = Reference(
+            Reference.Type.IMPLICIT, False, identifier="incorrect", line_number=12
+        )
 
         checker = linkchecker.LinkChecker([reference_2], {})
         checker.find_link_for_identifier(reference_expl_ok)
@@ -46,42 +61,63 @@ class TestLinkChecker(unittest.TestCase):
         self.assertEqual(checker.errors[0].lineno, 12)
 
     def test_correct_extension(self):
-        correct_ref = Reference(Reference.Type.EXPLICIT, False,
-                                link="k01.html", line_number=10)
-        html_instead_img = Reference(Reference.Type.EXPLICIT, True,
-                                     link="k01.html", line_number=1)
-        jpq_instead_html = Reference(Reference.Type.EXPLICIT, False,
-                                     link="k01.jpg", line_number=2)
-        md_instead_html = Reference(Reference.Type.EXPLICIT, False,
-                                    link="k01.md", line_number=3)
+        correct_ref = Reference(
+            Reference.Type.EXPLICIT, False, link="k01.html", line_number=10
+        )
+        html_instead_img = Reference(
+            Reference.Type.EXPLICIT, True, link="k01.html", line_number=1
+        )
+        jpq_instead_html = Reference(
+            Reference.Type.EXPLICIT, False, link="k01.jpg", line_number=2
+        )
+        md_instead_html = Reference(
+            Reference.Type.EXPLICIT, False, link="k01.md", line_number=3
+        )
 
         checker = linkchecker.LinkChecker([], {})
         checker.is_correct_extension(self.get_path(correct_ref), correct_ref)
         self.assertEqual(checker.errors, [])
-        checker.is_correct_extension(self.get_path(html_instead_img),
-                                     html_instead_img)
-        checker.is_correct_extension(self.get_path(jpq_instead_html),
-                                     jpq_instead_html)
-        checker.is_correct_extension(self.get_path(md_instead_html),
-                                     md_instead_html)
+        checker.is_correct_extension(self.get_path(html_instead_img), html_instead_img)
+        checker.is_correct_extension(self.get_path(jpq_instead_html), jpq_instead_html)
+        checker.is_correct_extension(self.get_path(md_instead_html), md_instead_html)
         self.assertEqual(len(checker.errors), 3)
         for i in range(len(checker.errors)):
             self.assertEqual(checker.errors[i].lineno, i + 1)
 
     def test_duplicities(self):
-        ref_1 = Reference(Reference.Type.EXPLICIT, False, identifier="link_1",
-                          link="k01.html", line_number=1)
-        ref_2 = Reference(Reference.Type.EXPLICIT, False, identifier="link_2",
-                          link="k01.html", line_number=2)
+        ref_1 = Reference(
+            Reference.Type.EXPLICIT,
+            False,
+            identifier="link_1",
+            link="k01.html",
+            line_number=1,
+        )
+        ref_2 = Reference(
+            Reference.Type.EXPLICIT,
+            False,
+            identifier="link_2",
+            link="k01.html",
+            line_number=2,
+        )
 
         checker = linkchecker.LinkChecker([ref_1, ref_2], {})
         checker.find_label_duplicates()
         self.assertEqual(checker.errors, [])
 
-        ref_3 = Reference(Reference.Type.EXPLICIT, False, identifier="link_1",
-                          link="k01.html", line_number=1)
-        ref_4 = Reference(Reference.Type.EXPLICIT, False, identifier="link_2",
-                          link="k01.html", line_number=2)
+        ref_3 = Reference(
+            Reference.Type.EXPLICIT,
+            False,
+            identifier="link_1",
+            link="k01.html",
+            line_number=1,
+        )
+        ref_4 = Reference(
+            Reference.Type.EXPLICIT,
+            False,
+            identifier="link_2",
+            link="k01.html",
+            line_number=2,
+        )
 
         checker = linkchecker.LinkChecker([ref_1, ref_2, ref_3], {})
         checker.find_label_duplicates()
@@ -95,20 +131,34 @@ class TestLinkChecker(unittest.TestCase):
 
     def test_target_exist(self):
         # add testing of hand-made temp file existence
-        ref_1 = Reference(Reference.Type.EXPLICIT, False, identifier="link_1",
-                          link="nonsense path with space", line_number=1)
+        ref_1 = Reference(
+            Reference.Type.EXPLICIT,
+            False,
+            identifier="link_1",
+            link="nonsense path with space",
+            line_number=1,
+        )
 
         checker = linkchecker.LinkChecker([], {})
-        checker.target_exists(self.get_path(ref_1), ref_1,
-                              "nonsenspath with space")
+        checker.target_exists(self.get_path(ref_1), ref_1, "nonsenspath with space")
         self.assertEqual(len(checker.errors), 1)
         self.assertEqual(checker.errors[0].lineno, 1)
 
     def test_www_unchecked(self):
-        ref_1 = Reference(Reference.Type.INLINE, False, identifier="link_1",
-                          link="WWW.google.de", line_number=1)
-        ref_2 = Reference(Reference.Type.INLINE, False, identifier="link_2",
-                          link="www.google.cz", line_number=2)
+        ref_1 = Reference(
+            Reference.Type.INLINE,
+            False,
+            identifier="link_1",
+            link="WWW.google.de",
+            line_number=1,
+        )
+        ref_2 = Reference(
+            Reference.Type.INLINE,
+            False,
+            identifier="link_2",
+            link="www.google.cz",
+            line_number=2,
+        )
         for ref in [ref_1, ref_2]:
             ref.file_path = "path"
 

--- a/tests/quality_assurance/testMeta.py
+++ b/tests/quality_assurance/testMeta.py
@@ -1,6 +1,4 @@
-#pylint: disable=too-many-public-methods,import-error,too-few-public-methods,missing-docstring,unused-variable,multiple-imports
+# pylint: disable=too-many-public-methods,import-error,too-few-public-methods,missing-docstring,unused-variable,multiple-imports
 import itertools
 import unittest
 import MAGSBS.mparser, MAGSBS.quality_assurance
-
-

--- a/tests/quality_assurance/testPageNumbersWithoutDashes.py
+++ b/tests/quality_assurance/testPageNumbersWithoutDashes.py
@@ -1,35 +1,35 @@
-#pylint: disable=too-many-public-methods,import-error,too-few-public-methods,missing-docstring,unused-variable
+# pylint: disable=too-many-public-methods,import-error,too-few-public-methods,missing-docstring,unused-variable
 # absolute imports are fine: test cases are running from the source root anyway
 import MAGSBS.quality_assurance.markdown as ma
 import MAGSBS.quality_assurance.meta as meta
 
 import unittest
 
+
 class TestPageNumbersWithoutDashes(unittest.TestCase):
     def test_normal_page_numbers_work_fine(self):
         checker = ma.PageNumbersWithoutDashes()
-        result = checker.worker({1: ['|| - Seite 8 -']})
+        result = checker.worker({1: ["|| - Seite 8 -"]})
         self.assertEqual(result, None)
 
     def test_normal_page_numbers_without_spaceswork_fine(self):
         checker = ma.PageNumbersWithoutDashes()
-        result = checker.worker({1: ['||-Seite 8-']})
+        result = checker.worker({1: ["||-Seite 8-"]})
         self.assertEqual(result, None)
 
     def test_that_missing_leading_dash_is_detected(self):
         checker = ma.PageNumbersWithoutDashes()
-        result = checker.worker({1: ['|| Seite 8 -']})
+        result = checker.worker({1: ["|| Seite 8 -"]})
         self.assertTrue(isinstance(result, meta.ErrorMessage))
 
     def test_that_missing_trailing_dash_is_detected(self):
         checker = ma.PageNumbersWithoutDashes()
-        result = checker.worker({1: ['|| - Seite 8']})
+        result = checker.worker({1: ["|| - Seite 8"]})
         self.assertTrue(isinstance(result, meta.ErrorMessage))
 
     def test_that_spaces_at_the_end_dont_trigger(self):
         checker = ma.PageNumbersWithoutDashes()
-        result = checker.worker({1: ['|| - Seite 8 - ']})
+        result = checker.worker({1: ["|| - Seite 8 - "]})
         self.assertFalse(isinstance(result, meta.ErrorMessage))
-        result = checker.worker({1: ['|| - Seite 8 -\t']})
+        result = checker.worker({1: ["|| - Seite 8 -\t"]})
         self.assertFalse(isinstance(result, meta.ErrorMessage))
-

--- a/tests/quality_assurance/testParagraphMayNotEndOnBackslash.py
+++ b/tests/quality_assurance/testParagraphMayNotEndOnBackslash.py
@@ -1,19 +1,21 @@
-#pylint: disable=too-many-public-methods,import-error,too-few-public-methods,missing-docstring,unused-variable
+# pylint: disable=too-many-public-methods,import-error,too-few-public-methods,missing-docstring,unused-variable
 import unittest
 import MAGSBS.quality_assurance as qa
 import MAGSBS.quality_assurance.markdown as ma
 
+
 class test_ParagraphMayNotEndOnBackslash(unittest.TestCase):
     def test_normal_paragraphs_are_recognized(self):
-        content1 = {1 : ['line1', 'line2', 'line3']}
-        content2 = {1 : ['line1', 'line2', 'line3',], 8 : ['foo', 'bar']}
-        self.assertEqual(ma.ParagraphMayNotEndOnBackslash().worker(content1,
-            'dummy'), None)
-        self.assertEqual(ma.ParagraphMayNotEndOnBackslash().worker(content2,
-            'dummy'), None)
+        content1 = {1: ["line1", "line2", "line3"]}
+        content2 = {1: ["line1", "line2", "line3",], 8: ["foo", "bar"]}
+        self.assertEqual(
+            ma.ParagraphMayNotEndOnBackslash().worker(content1, "dummy"), None
+        )
+        self.assertEqual(
+            ma.ParagraphMayNotEndOnBackslash().worker(content2, "dummy"), None
+        )
 
     def test_that_error_case_is_correctly_identified(self):
-        content = {1:['a','b','c\\'], 5:['dummy']}
-        err_obj = ma.ParagraphMayNotEndOnBackslash().worker(content, 'dummy')
+        content = {1: ["a", "b", "c\\"], 5: ["dummy"]}
+        err_obj = ma.ParagraphMayNotEndOnBackslash().worker(content, "dummy")
         self.assertTrue(isinstance(err_obj, qa.meta.ErrorMessage))
-

--- a/tests/quality_assurance/testSpacingInFormulaShouldBeDoneWithQuad.py
+++ b/tests/quality_assurance/testSpacingInFormulaShouldBeDoneWithQuad.py
@@ -1,17 +1,18 @@
-#pylint: disable=too-many-public-methods,import-error,too-few-public-methods,missing-docstring,unused-variable,multiple-imports
+# pylint: disable=too-many-public-methods,import-error,too-few-public-methods,missing-docstring,unused-variable,multiple-imports
 import unittest
 
 from MAGSBS.quality_assurance.latex import SpacingInFormulaShouldBeDoneWithQuad
 
+
 def check(lnum, pos, formula):
     return SpacingInFormulaShouldBeDoneWithQuad().worker({(lnum, pos): formula})
 
+
 class TestSpacingInFormulaShouldBeDoneWithQuad(unittest.TestCase):
     def test_error_is_recognized(self):
-        formula = r'Look at: $\pi\ \ \ \ \ \tau$'
+        formula = r"Look at: $\pi\ \ \ \ \ \tau$"
         self.assertNotEqual(check(88, 1, formula), None)
 
     def test_normal_formulas_are_not_incorrectly_recognized(self):
         formula = r"Look at: $\pi\tau\ \foo\bar$"
         self.assertEqual(check(99, 1, formula), None)
-

--- a/tests/quality_assurance/testTextInItemizeShouldntStartWithItemizeCharacter.py
+++ b/tests/quality_assurance/testTextInItemizeShouldntStartWithItemizeCharacter.py
@@ -1,81 +1,89 @@
-#pylint: disable=too-many-public-methods,import-error,too-few-public-methods,missing-docstring,unused-variable
+# pylint: disable=too-many-public-methods,import-error,too-few-public-methods,missing-docstring,unused-variable
 import unittest
 import MAGSBS.errors as errors
 import MAGSBS.quality_assurance
 import MAGSBS.quality_assurance.markdown as ma
 
+
 def is_error(obj):
     return isinstance(obj, MAGSBS.quality_assurance.meta.ErrorMessage)
 
+
 class TestTextInItemizeShouldntStartWithItemizeCharacter(unittest.TestCase):
     def run_checker(self, *arguments):
-        return ma.TextInItemizeShouldntStartWithItemizeCharacter().\
-                worker(*arguments)
+        return ma.TextInItemizeShouldntStartWithItemizeCharacter().worker(*arguments)
 
     def test_that_normal_itemizes_are_notaffected(self):
-        file = {1:['- item', '- item', '- another'],
-            6: ['+ item', '+ item']}
+        file = {1: ["- item", "- item", "- another"], 6: ["+ item", "+ item"]}
         self.assertTrue(self.run_checker(file) is None)
 
     def test_that_normale_enumerations_dont_trigger_error(self):
-        file = {1:['1. item', '2. item', '3. another'],
-            6: ['+ item', '+ item']}
+        file = {1: ["1. item", "2. item", "3. another"], 6: ["+ item", "+ item"]}
         self.assertTrue(self.run_checker(file) is None)
 
     def test_that_itemize_with_enumeration_is_recognized(self):
-        file = {1:['- item', '- item', '- 3. another']}
+        file = {1: ["- item", "- item", "- 3. another"]}
         self.assertTrue(is_error(self.run_checker(file)))
-        file = {1:['* item', '* item', '* 3. another']}
+        file = {1: ["* item", "* item", "* 3. another"]}
         self.assertTrue(is_error(self.run_checker(file)))
 
     def test_that_enumerations_with_itemizes_are_recognized(self):
-        file = {1:['1. item', '2. item', '3. - another']}
+        file = {1: ["1. item", "2. item", "3. - another"]}
         self.assertTrue(is_error(self.run_checker(file)))
 
     def test_that_enumeration_with_enumeration_is_recognized(self):
-        file = {1:['1. item', '2. item', '3. 1. another']}
+        file = {1: ["1. item", "2. item", "3. 1. another"]}
         self.assertTrue(is_error(self.run_checker(file)))
 
     def test_that_indented_lists_work_as_well(self):
-        file = {1:['1. item', '    1. item', '    2. 1. another']}
+        file = {1: ["1. item", "    1. item", "    2. 1. another"]}
         self.assertTrue(is_error(self.run_checker(file)))
 
     def test_that_number_without_dot_is_not_recognized_as_sublist(self):
-        file = {1:['- item', '- item', '- 15% another']}
+        file = {1: ["- item", "- item", "- 15% another"]}
         self.assertEqual(self.run_checker(file), None)
 
     def test_that_(self):
-        data = {1:['- - - -']}
+        data = {1: ["- - - -"]}
         self.assertEqual(self.run_checker(data), None)
-        data = {3:['* * * * *']}
+        data = {3: ["* * * * *"]}
         self.assertEqual(self.run_checker(data), None)
 
     def test_that_bold_text_is_not_threated_as_sublist(self):
-        data = {1:['muh'], 3:['- **foo**', '- bar', '- baz']}
+        data = {1: ["muh"], 3: ["- **foo**", "- bar", "- baz"]}
         self.assertEqual(self.run_checker(data), None)
 
     def test_that_(self):
-        data = {1:['muh'], 3:['- 14.08.2019', '- bar', '- baz']}
+        data = {1: ["muh"], 3: ["- 14.08.2019", "- bar", "- baz"]}
         self.assertEqual(self.run_checker(data), None)
 
     def test_that_slanted_text_is_not_treated_as_error(self):
-        text = {1: ['- fooobar',
-                '- *Cost = max \# of simultaneous accesses to a single bank*']}
+        text = {
+            1: [
+                "- fooobar",
+                "- *Cost = max \# of simultaneous accesses to a single bank*",
+            ]
+        }
         self.assertEqual(self.run_checker(text), None)
 
     def test_years_are_not_recognized_as_itemize_character(self):
-        text = {1: ['- 2008.', '- 2009.']}
+        text = {1: ["- 2008.", "- 2009."]}
         self.assertEqual(self.run_checker(text), None)
 
     def test_that_bold_text_is_ok(self):
-        text = {1 : ['normal', 'text'],
-                4: ['* *blahblah*', '* *barbar*', '* *foobar*', '* *blubblub*',
-                    '* *last*']}
+        text = {
+            1: ["normal", "text"],
+            4: ["* *blahblah*", "* *barbar*", "* *foobar*", "* *blubblub*", "* *last*"],
+        }
         self.assertEqual(self.run_checker(text), None)
 
     def test_that_hyphens_in_line_are_fine(self):
-        text = {1 : ['- this is normal text',
-            '- without much sense', '- foo',
-            '-    Je viens de recevoir un petit héritage - de ma grand-']}
+        text = {
+            1: [
+                "- this is normal text",
+                "- without much sense",
+                "- foo",
+                "-    Je viens de recevoir un petit héritage - de ma grand-",
+            ]
+        }
         self.assertEqual(self.run_checker(text), None)
-

--- a/tests/quality_assurance/testToDosInImageDescriptionsAreBad.py
+++ b/tests/quality_assurance/testToDosInImageDescriptionsAreBad.py
@@ -1,39 +1,42 @@
-#pylint: disable=too-many-public-methods,import-error,too-few-public-methods,missing-docstring,unused-variable
+# pylint: disable=too-many-public-methods,import-error,too-few-public-methods,missing-docstring,unused-variable
 import unittest
 from MAGSBS.quality_assurance.meta import ErrorMessage
 import MAGSBS.quality_assurance.markdown as ma
 
+
 class TestToDosInImageDescriptionsAreBad(unittest.TestCase):
     def is_error(self, potential_error):
-        self.assertTrue(isinstance(potential_error, ErrorMessage),
-            "Expected an object of type quality_assurance.meta.ErrorMessage, " + \
-            "got " + repr(potential_error))
+        self.assertTrue(
+            isinstance(potential_error, ErrorMessage),
+            "Expected an object of type quality_assurance.meta.ErrorMessage, "
+            + "got "
+            + repr(potential_error),
+        )
 
     def test_lower_case_is_detected(self):
-        line = 'Bildbeschreibung, todo'
+        line = "Bildbeschreibung, todo"
         self.is_error(ma.ToDosInImageDescriptionsAreBad().check(1, line))
-        line = 'todo, muss beschrieben werden'
+        line = "todo, muss beschrieben werden"
         self.is_error(ma.ToDosInImageDescriptionsAreBad().check(1, line))
 
     def test_lower_case_with_space_is_detected(self):
-        line = 'to do, muss beschrieben werden'
+        line = "to do, muss beschrieben werden"
         self.is_error(ma.ToDosInImageDescriptionsAreBad().check(1, line))
-        line = 'Bildbeschreibung, to  do'
+        line = "Bildbeschreibung, to  do"
         self.is_error(ma.ToDosInImageDescriptionsAreBad().check(1, line))
 
     def test_camel_case_is_dtected(self):
-        line = 'Bildbeschreibung, ToDo'
+        line = "Bildbeschreibung, ToDo"
         self.is_error(ma.ToDosInImageDescriptionsAreBad().check(1, line))
-        line = 'Bildbeschreibung, To Do'
+        line = "Bildbeschreibung, To Do"
         self.is_error(ma.ToDosInImageDescriptionsAreBad().check(1, line))
 
     def test_full_caps_is_detected(self):
-        line = 'Bildbeschreibung, TODO'
+        line = "Bildbeschreibung, TODO"
         self.is_error(ma.ToDosInImageDescriptionsAreBad().check(1, line))
-        line = 'TO DO: beschreibe mich'
+        line = "TO DO: beschreibe mich"
         self.is_error(ma.ToDosInImageDescriptionsAreBad().check(1, line))
 
     def test_the_words_to_and_do_are_ignored_otherwise(self):
-        line = 'This has nothing to do with incomplete descriptions.'
+        line = "This has nothing to do with incomplete descriptions."
         self.assertTrue(ma.ToDosInImageDescriptionsAreBad().check(1, line) is None)
-

--- a/tests/quality_assurance/testTooManyHeadings.py
+++ b/tests/quality_assurance/testTooManyHeadings.py
@@ -1,9 +1,10 @@
-#pylint: disable=too-many-public-methods,import-error,too-few-public-methods,missing-docstring,unused-variable,multiple-imports
+# pylint: disable=too-many-public-methods,import-error,too-few-public-methods,missing-docstring,unused-variable,multiple-imports
 import random
 import unittest
 
 import MAGSBS.quality_assurance.markdown as markdown
 from MAGSBS import datastructures
+
 
 def make_headings(**headings):
     """Transform {'path':[1,2,3]) into {'path' : [<heading_object>, ...]}, where
@@ -13,16 +14,17 @@ def make_headings(**headings):
         bilder -> k01/bilder.md"""
     proper_headings = {}
     for path, headings in headings.items():
-        if path.startswith('k'):
-            path = '{0}/{0}.md'.format(path, path[:3])
+        if path.startswith("k"):
+            path = "{0}/{0}.md".format(path, path[:3])
         else:
-            path = 'k01/%s.md' % path
+            path = "k01/%s.md" % path
         proper_headings[path] = []
         for level in headings:
-            text = 'h%s%s' % (level, random.randint(1,999999999))
+            text = "h%s%s" % (level, random.randint(1, 999999999))
             h = datastructures.Heading(text, level)
             proper_headings[path].append(h)
     return proper_headings
+
 
 def check(headings):
     return markdown.TooManyHeadings().worker(headings)
@@ -30,20 +32,19 @@ def check(headings):
 
 class TestTooManyHeadings(unittest.TestCase):
     def test_only_a_few_headings_dont_trigger(self):
-        h = make_headings(k01 = [1, 2, 3, 4, 2, 3, 4, 2, 2, 2, 2, 2, 2, 2, 2])
+        h = make_headings(k01=[1, 2, 3, 4, 2, 3, 4, 2, 2, 2, 2, 2, 2, 2, 2])
         self.assertFalse(check(h))
 
     def test_that_many_headings_of_same_level_trigger(self):
-        h = make_headings(k01 = [1] + [2] * 22)
+        h = make_headings(k01=[1] + [2] * 22)
         self.assertTrue(check(h))
-        h = make_headings(k01 = [1, 2] + [3] * 22)
+        h = make_headings(k01=[1, 2] + [3] * 22)
         self.assertTrue(check(h))
 
     def test_that_nested_structures_trigger_too(self):
-        h = make_headings(k02 = [1] + [2, 3] * 22)
+        h = make_headings(k02=[1] + [2, 3] * 22)
         self.assertTrue(check(h))
 
         def test_that_image_files_are_ignored(self):
-            h = make_headings(bilder = [1] + [2] * 2222)
+            h = make_headings(bilder=[1] + [2] * 2222)
             self.assertFalse(check(h))
-

--- a/tests/quality_assurance/testUseProperCommandsForMathOperatorsAndFunctions.py
+++ b/tests/quality_assurance/testUseProperCommandsForMathOperatorsAndFunctions.py
@@ -1,29 +1,26 @@
-#pylint: disable=too-many-public-methods,import-error,too-few-public-methods,missing-docstring,unused-variable,multiple-imports
+# pylint: disable=too-many-public-methods,import-error,too-few-public-methods,missing-docstring,unused-variable,multiple-imports
 import unittest
 
 from MAGSBS.quality_assurance import UseProperCommandsForMathOperatorsAndFunctions
 
-check = lambda x: UseProperCommandsForMathOperatorsAndFunctions().worker({(1,1): x})
+check = lambda x: UseProperCommandsForMathOperatorsAndFunctions().worker({(1, 1): x})
+
 
 class TestUseProperCommandsForMathOperatorsAndFunctions(unittest.TestCase):
     def test_that_normal_functions_dont_trigger(self):
-        self.assertFalse(check('foobar'))
-        self.assertFalse(check(r'\gamma\alpha'))
+        self.assertFalse(check("foobar"))
+        self.assertFalse(check(r"\gamma\alpha"))
 
     def test_that_properly_set_operators_dont_trigger(self):
-        self.assertFalse(check(r'\max\{1,i\mid \ldots\}'))
-        self.assertFalse(check(r'\sin(\pi)'))
-        self.assertFalse(check(r'\cos(\frac\pi2)'))
+        self.assertFalse(check(r"\max\{1,i\mid \ldots\}"))
+        self.assertFalse(check(r"\sin(\pi)"))
+        self.assertFalse(check(r"\cos(\frac\pi2)"))
 
     def test_that_operators_and_funcs_without_backslash_trigger(self):
-        self.assertTrue(check(r'max\{1,i\mid \ldots\}'))
-        self.assertTrue(check(r'sin(\pi)'))
-        self.assertTrue(check(r'cos(\frac\pi2)'))
+        self.assertTrue(check(r"max\{1,i\mid \ldots\}"))
+        self.assertTrue(check(r"sin(\pi)"))
+        self.assertTrue(check(r"cos(\frac\pi2)"))
 
- 
     def test_infix_matches_dont_trigger(self):
-        self.assertFalse(check(r'A\setminus B'))
-        self.assertFalse(check(r'A\setminus B'))
-
- 
-
+        self.assertFalse(check(r"A\setminus B"))
+        self.assertFalse(check(r"A\setminus B"))

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,27 +1,29 @@
-#pylint: disable=too-many-public-methods,import-error,too-few-public-methods,missing-docstring,unused-variable,multiple-imports
+# pylint: disable=too-many-public-methods,import-error,too-few-public-methods,missing-docstring,unused-variable,multiple-imports
 import os
 import shutil
 import tempfile
 import unittest
 from MAGSBS.common import is_within_lecture
 
+
 def touch(path):
     """Create the path recursively. If the argument string does not end on a
     slash, it is taken as file name and created as an empty file below the
     prefix."""
-    if path.endswith('/'):
+    if path.endswith("/"):
         os.makedirs(path, exist_ok=True)
     else:
         os.makedirs(os.path.dirname(os.path.abspath(path)), exist_ok=True)
-        with open(path, 'w') as f:
+        with open(path, "w") as f:
             f.write("\n")
+
 
 class TestCommon(unittest.TestCase):
     def setUp(self):
         self.original_directory = os.getcwd()
         self.tmpdir = tempfile.mkdtemp()
         os.chdir(self.tmpdir)
-        self.call_cleanup_on_me = None # used for the OutputFormatters
+        self.call_cleanup_on_me = None  # used for the OutputFormatters
 
     def tearDown(self):
         os.chdir(self.original_directory)
@@ -29,10 +31,8 @@ class TestCommon(unittest.TestCase):
         if self.call_cleanup_on_me:
             self.call_cleanup_on_me.cleanup()
 
-
-
     def test_that_a_file_that_doesnt_exist_is_invalid(self):
-        self.assertFalse(is_within_lecture('/highway/to/hell'))
+        self.assertFalse(is_within_lecture("/highway/to/hell"))
 
     def test_that_random_path_is_not_considered_correct(self):
         touch("mypath/anotherpath/subdirectory/")
@@ -57,12 +57,10 @@ class TestCommon(unittest.TestCase):
         self.assertTrue(is_within_lecture("lecture/k01/bilder"))
 
     def test_that_files_in_lecture_root_work(self):
-        touch("myroot/k01//k01.md") # a sample directory
+        touch("myroot/k01//k01.md")  # a sample directory
         touch("myroot/info.md")
         self.assertTrue(is_within_lecture("myroot/info.md"))
 
     def test_that_directory_outside_a_lecture_returns_false(self):
         touch("myroot/")
         self.assertFalse(is_within_lecture("myroot"))
-
-

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,4 @@
-#pylint: disable=too-many-public-methods,import-error,too-few-public-methods,missing-docstring,unused-variable,multiple-imports
+# pylint: disable=too-many-public-methods,import-error,too-few-public-methods,missing-docstring,unused-variable,multiple-imports
 import unittest
 from unittest.mock import patch
 
@@ -9,12 +9,14 @@ import tempfile
 from MAGSBS import config, common, errors
 from MAGSBS.config import MetaInfo
 
-conf = lambda conf, version=str(config.VERSION): config.LectureMetaData(conf,
-        distutils.version.StrictVersion(version))
+conf = lambda conf, version=str(config.VERSION): config.LectureMetaData(
+    conf, distutils.version.StrictVersion(version)
+)
+
 
 def write(c):
     """Change an attibute in LectureMetaData to enforce the write."""
-    c[MetaInfo.SemesterOfEdit] = 'fake'
+    c[MetaInfo.SemesterOfEdit] = "fake"
     c.write()
 
 
@@ -29,49 +31,50 @@ class Testconf(unittest.TestCase):
         shutil.rmtree(self.tmpdir)
 
     def test_that_version_is_written(self):
-        c = conf('foo')
+        c = conf("foo")
         write(c)
-        with open('foo') as f:
-            self.assertTrue('version>' + str(config.VERSION) in f.read())
+        with open("foo") as f:
+            self.assertTrue("version>" + str(config.VERSION) in f.read())
 
     def test_that_outdated_converter_raises_exception(self):
-        c = conf('path', '10.9')
+        c = conf("path", "10.9")
         write(c)
         with self.assertRaises(errors.ConfigurationError):
-            conf('path', '0.9').read()
+            conf("path", "0.9").read()
 
     def test_that_outdated_conf_is_silently_upgraded(self):
-        c = conf('path', '0.9')
+        c = conf("path", "0.9")
         write(c)
-        conf('path', '20.2').read() # silently upgrades?
-        with open('path') as f:
+        conf("path", "20.2").read()  # silently upgrades?
+        with open("path") as f:
             data = f.read()
-            self.assertTrue('version>20.2' in data,
-                    "expected version number 20.2, got: " + repr(data))
+            self.assertTrue(
+                "version>20.2" in data,
+                "expected version number 20.2, got: " + repr(data),
+            )
 
     def test_that_same_version_just_works_fine(self):
-        c = conf('path', '0.9')
+        c = conf("path", "0.9")
         write(c)
         # this does not raise:
-        conf('path', '0.9').read()
+        conf("path", "0.9").read()
         # bug fixes are treated as equal version
-        conf('path', '0.9.5').read()
+        conf("path", "0.9.5").read()
 
-    @patch('MAGSBS.common.WarningRegistry')
+    @patch("MAGSBS.common.WarningRegistry")
     def test_that_newer_bugfix_version_emits_warning(self, wr_mock):
-        c = conf('path', '0.9.5')
+        c = conf("path", "0.9.5")
         write(c)
-        conf('path', '0.9').read() # this registers the warning
+        conf("path", "0.9").read()  # this registers the warning
         wr_mock.register_warning("foo")
         self.assertEqual(len(wr_mock.register_warning.mock_calls), 1)
 
     def test_unparseable_version_number_raises(self):
-        c = conf('path', '6.6.6')
+        c = conf("path", "6.6.6")
         write(c)
-        with open('path') as f: # alter version number
+        with open("path") as f:  # alter version number
             stuff = f.read()
-        with open('path', 'w') as f:
-            f.write(stuff.replace('6.6.6', '6.8~beta.9'))
+        with open("path", "w") as f:
+            f.write(stuff.replace("6.6.6", "6.8~beta.9"))
         with self.assertRaises(errors.ConfigurationError) as e:
-            conf('path').read()
-
+            conf("path").read()

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -1,63 +1,65 @@
-#pylint: disable=too-many-public-methods,import-error,too-few-public-methods,missing-docstring,unused-variable,multiple-imports
+# pylint: disable=too-many-public-methods,import-error,too-few-public-methods,missing-docstring,unused-variable,multiple-imports
 import unittest, sys
-sys.path.insert(0, '.') # just in case
+
+sys.path.insert(0, ".")  # just in case
 import MAGSBS.datastructures as datastructures
 import MAGSBS.errors as errors
-from  MAGSBS.common import setup_i18n
+from MAGSBS.common import setup_i18n
 import os
 
 setup_i18n()
 
+
 class test_gen_id(unittest.TestCase):
     def test_that_spaces_are_replaced_by_hyphens(self):
-        self.assertEqual(datastructures.gen_id('hey du da'), 'hey-du-da')
+        self.assertEqual(datastructures.gen_id("hey du da"), "hey-du-da")
 
     def test_that_leading_hyphens_or_spaces_are_ignored(self):
-        self.assertEqual(datastructures.gen_id('  - kk'), 'kk')
+        self.assertEqual(datastructures.gen_id("  - kk"), "kk")
 
     def test_that_hypens_in_middle_are_preserved(self):
-        heading = 'Remarkable - MarkDown saves time'
+        heading = "Remarkable - MarkDown saves time"
         result = datastructures.gen_id(heading)
-        self.assertTrue('able---' in result,
-                "expected 'remarkable---' in id, got '{}'".format(result))
+        self.assertTrue(
+            "able---" in result,
+            "expected 'remarkable---' in id, got '{}'".format(result),
+        )
 
     def test_that_exclamation_marks_etc_do_not_cause_trouble(self):
-        exclamation = 'this ! is bad'
-        self.assertEqual(datastructures.gen_id(exclamation), 'this-is-bad')
-        question = 'do I ? know'
-        self.assertEqual(datastructures.gen_id(question), 'do-i-know')
+        exclamation = "this ! is bad"
+        self.assertEqual(datastructures.gen_id(exclamation), "this-is-bad")
+        question = "do I ? know"
+        self.assertEqual(datastructures.gen_id(question), "do-i-know")
 
     def test_that_leading_numbers_are_ignored(self):
-        self.assertEqual(datastructures.gen_id('01 hints and tips'),
-            'hints-and-tips')
+        self.assertEqual(datastructures.gen_id("01 hints and tips"), "hints-and-tips")
 
     def test_that_special_characters_are_ignored(self):
-        self.assertEqual(datastructures.gen_id('$$foo##!bar'), 'foobar')
+        self.assertEqual(datastructures.gen_id("$$foo##!bar"), "foobar")
 
     def test_numbers_in_the_middle_are_ok(self):
-        self.assertEqual(datastructures.gen_id('a1b'), 'a1b')
-
+        self.assertEqual(datastructures.gen_id("a1b"), "a1b")
 
     def test_that_umlauts_are_still_contained(self):
-        self.assertEqual(datastructures.gen_id('ärgerlich'), 'ärgerlich')
+        self.assertEqual(datastructures.gen_id("ärgerlich"), "ärgerlich")
 
     def test_that_case_is_converted_to_lower_case(self):
-        self.assertEqual(datastructures.gen_id('uGlYWriTtEn'), 'uglywritten')
+        self.assertEqual(datastructures.gen_id("uGlYWriTtEn"), "uglywritten")
 
     def test_that_empty_id_is_ok(self):
         # no exception, please
-        self.assertEqual(datastructures.gen_id(''), '')
+        self.assertEqual(datastructures.gen_id(""), "")
 
     def test_that_dots_at_beginning_are_ignored(self):
-        self.assertFalse(datastructures.gen_id('...foo').startswith('.'))
+        self.assertFalse(datastructures.gen_id("...foo").startswith("."))
 
     def test_that_dots_in_middle_are_preserved(self):
-        self.assertEqual(datastructures.gen_id('it . works'), 'it-.-works')
+        self.assertEqual(datastructures.gen_id("it . works"), "it-.-works")
 
     def test_that_no_double_hyphens_occur(self):
-        examples = ['construct ) cases', '()foo', 'a | b']
+        examples = ["construct ) cases", "()foo", "a | b"]
         for text in examples:
-            self.assertTrue('--' not in datastructures.gen_id(text))
+            self.assertTrue("--" not in datastructures.gen_id(text))
 
 
 ################################################################################
@@ -65,64 +67,85 @@ class test_gen_id(unittest.TestCase):
 # pylint: disable=protected-access
 class TestFileCache(unittest.TestCase):
     def test_that_all_files_are_contained(self):
-        files = [('anh03', 0, ('anh0301.md', 'anh0302.md')),
-                ('k20', 0, ('k20.md',)),
-                ('anh04', 0, ('anh04.md',))]
+        files = [
+            ("anh03", 0, ("anh0301.md", "anh0302.md")),
+            ("k20", 0, ("k20.md",)),
+            ("anh04", 0, ("anh04.md",)),
+        ]
         f = datastructures.FileCache(files)
         for file in [e[2] for e in files]:
-            file = (file[0] if not isinstance(file, str) else file)
+            file = file[0] if not isinstance(file, str) else file
             self.assertTrue(file in f, "%s should be contained in the cache" % file)
 
     def test_that_files_are_grouped_correctly(self):
-        appendix =  ('anh03', 0, ('anh0301.md', 'anh0302.md'))
-        preface = ('v04', 0, ('v04.md',))
-        main = ('blatt05', 0, ('blatt05.md',))
+        appendix = ("anh03", 0, ("anh0301.md", "anh0302.md"))
+        preface = ("v04", 0, ("v04.md",))
+        main = ("blatt05", 0, ("blatt05.md",))
         f = datastructures.FileCache((preface, main, appendix))
-        self.assertEqual(f._FileCache__preface[0][1], preface[2][0],
-                "%s should be contained in the preface group" % preface[2][0])
-        self.assertEqual(appendix[2][0], f._FileCache__appendix[0][1],
-                "%s should be contained in the appendix group" % appendix[2][0])
-        self.assertEqual(main[2][0], f._FileCache__main[0][1],
-                "%s should be contained in the main group" % main[2][0])
+        self.assertEqual(
+            f._FileCache__preface[0][1],
+            preface[2][0],
+            "%s should be contained in the preface group" % preface[2][0],
+        )
+        self.assertEqual(
+            appendix[2][0],
+            f._FileCache__appendix[0][1],
+            "%s should be contained in the appendix group" % appendix[2][0],
+        )
+        self.assertEqual(
+            main[2][0],
+            f._FileCache__main[0][1],
+            "%s should be contained in the main group" % main[2][0],
+        )
 
     def test_that_invalid_file_names_raise_exception(self):
         with self.assertRaises(errors.StructuralError):
-            datastructures.FileCache([('foo', 0, ('foobar.md',))])
+            datastructures.FileCache([("foo", 0, ("foobar.md",))])
 
     def test_that_get_neighbours_returns_correct_neighbours_or_none(self):
-        files = [('anh03', 0, ('anh0301.md', 'anh0302.md')),
-                ('v04', 0, ('v04.md',)), ('blatt05', 0, ('blatt05.md',))]
+        files = [
+            ("anh03", 0, ("anh0301.md", "anh0302.md")),
+            ("v04", 0, ("v04.md",)),
+            ("blatt05", 0, ("blatt05.md",)),
+        ]
         f = datastructures.FileCache(files)
         # this one has two neighbours
         # ToDo: "in" must be used
-        self.assertEqual(f.get_neighbours_for('blatt05/blatt05.md'),
-                (('v04', 'v04.md'), ('anh03', 'anh0301.md')))
+        self.assertEqual(
+            f.get_neighbours_for("blatt05/blatt05.md"),
+            (("v04", "v04.md"), ("anh03", "anh0301.md")),
+        )
         # this one has only a next
-        self.assertEqual(f.get_neighbours_for('v04/v04.md'),
-                (None, ('blatt05','blatt05.md')))
+        self.assertEqual(
+            f.get_neighbours_for("v04/v04.md"), (None, ("blatt05", "blatt05.md"))
+        )
         # this one has only a previous
-        self.assertEqual(f.get_neighbours_for('anh03/anh0302.md'),
-                (('anh03', 'anh0301.md'), None))
+        self.assertEqual(
+            f.get_neighbours_for("anh03/anh0302.md"), (("anh03", "anh0301.md"), None)
+        )
 
     def test_requesting_neighbours_for_not_existing_files_raises_exception(self):
-        f = datastructures.FileCache([('anh03', 0, ('anh0301.md',))])
+        f = datastructures.FileCache([("anh03", 0, ("anh0301.md",))])
         with self.assertRaises(errors.StructuralError):
-            #pylint: disable=pointless-statement
+            # pylint: disable=pointless-statement
             f.get_neighbours_for("fooo.md")
 
     def test_that_number_is_extracted_from_normal_file_name(self):
         self.assertEqual(2, datastructures.extract_chapter_number("k02.md"))
 
     def test_that_number_is_extracted_from_relative_paths_and_absolute_paths(self):
-        self.assertEqual(datastructures.extract_chapter_number(os.path.join("k04",
-            "k04.md")), 4)
-        self.assertEqual(datastructures.extract_chapter_number(os.path.join("c:", "k09",
-        "k09.md")), 9)
+        self.assertEqual(
+            datastructures.extract_chapter_number(os.path.join("k04", "k04.md")), 4
+        )
+        self.assertEqual(
+            datastructures.extract_chapter_number(os.path.join("c:", "k09", "k09.md")),
+            9,
+        )
         self.assertEqual(datastructures.extract_chapter_number("k08/k08.md"), 8)
 
     def test_that_subchapter_files_work(self):
-        self.assertEqual(datastructures.extract_chapter_number('k0501.md'), 5)
-        self.assertEqual(datastructures.extract_chapter_number('k060201.md'), 6)
+        self.assertEqual(datastructures.extract_chapter_number("k0501.md"), 5)
+        self.assertEqual(datastructures.extract_chapter_number("k060201.md"), 6)
 
     def test_that_non_two_digit_numbers_raise_structural_error(self):
         with self.assertRaises(errors.StructuralError):
@@ -133,5 +156,3 @@ class TestFileCache(unittest.TestCase):
         with self.assertRaises(errors.StructuralError):
             datastructures.extract_chapter_number("paper.md")
             datastructures.extract_chapter_number("k11_old.md")
-
-

--- a/tests/test_filesystem.py
+++ b/tests/test_filesystem.py
@@ -1,8 +1,5 @@
-#pylint: disable=too-many-public-methods,import-error,too-few-public-methods,missing-docstring,unused-variable
+# pylint: disable=too-many-public-methods,import-error,too-few-public-methods,missing-docstring,unused-variable
 import unittest, sys
-sys.path.insert(0, '.') # just in case
+
+sys.path.insert(0, ".")  # just in case
 import MAGSBS.filesystem as fs
-
-
-
-

--- a/tests/test_locale.py
+++ b/tests/test_locale.py
@@ -1,4 +1,4 @@
-#pylint: disable=too-many-public-methods,import-error,too-few-public-methods,missing-docstring,unused-variable,multiple-imports
+# pylint: disable=too-many-public-methods,import-error,too-few-public-methods,missing-docstring,unused-variable,multiple-imports
 import os
 import unittest
 from unittest.mock import patch
@@ -9,39 +9,44 @@ from MAGSBS.common import _get_localedir
 
 def fake_mo(actual_path, desired=None):
     if desired.lower() in actual_path.lower():
-        return [(os.path.join(desired, 'de', 'LC_MESSAGES'), [], ['matuc.mo'])]
+        return [(os.path.join(desired, "de", "LC_MESSAGES"), [], ["matuc.mo"])]
     else:
-        return [('./', (), ())]
+        return [("./", (), ())]
+
 
 fake_usr_local = lambda x: fake_mo(x, desired="/usr/share/locale")
-fake_c_program_files = lambda x: fake_mo(x, desired='C:\\ProgramData')
+fake_c_program_files = lambda x: fake_mo(x, desired="C:\\ProgramData")
 fake_none = lambda x: fake_mo(x, ".")
+
 
 def normalise_path(path):
     """Enable comparison of UNIX and Windows paths."""
-    return path.replace('\\', '/').lower()
-class test_locale(unittest.TestCase):
+    return path.replace("\\", "/").lower()
 
+
+class test_locale(unittest.TestCase):
     @patch("os.walk", fake_usr_local)
     @patch("sys.platform", "linux")
     def test_that_locale_is_available_Linux(self):
-        self.assertEqual(_get_localedir(), '/usr/share/locale')
+        self.assertEqual(_get_localedir(), "/usr/share/locale")
 
     @patch("os.walk", fake_usr_local)
     @patch("sys.platform", "darwin")
     def test_that_locale_is_available_OSX(self):
-        self.assertTrue(_get_localedir(), '/usr/share/locale')
+        self.assertTrue(_get_localedir(), "/usr/share/locale")
 
     @patch("os.walk", fake_c_program_files)
     @patch("sys.platform", "win32")
-    @patch("os.getenv", lambda x: r'c:\ProgramData')
+    @patch("os.getenv", lambda x: r"c:\ProgramData")
     def test_that_locale_is_available_Windows(self):
         # platform unknown, as is the os.sep, use slash *always*
-        self.assertEqual(normalise_path(_get_localedir()),
-                "c:/programdata/agsbs/matuc/locale")
+        self.assertEqual(
+            normalise_path(_get_localedir()), "c:/programdata/agsbs/matuc/locale"
+        )
 
         # ToDo: test name ergibt keinen sinn, Testaufbau schlecht. Daten aus
         # Code sammeln, assert* ausführen
+
     @patch("os.walk", fake_none)
     def test_install_locale_returns_none(self):
         self.assertEqual(_get_localedir(), None)

--- a/tests/test_mparser.py
+++ b/tests/test_mparser.py
@@ -1,14 +1,15 @@
-#pylint: disable=too-many-public-methods,import-error,too-few-public-methods,missing-docstring,unused-variable
+# pylint: disable=too-many-public-methods,import-error,too-few-public-methods,missing-docstring,unused-variable
 import unittest, sys, collections, os, itertools
-sys.path.insert(0, '.') # just in case
+
+sys.path.insert(0, ".")  # just in case
 import MAGSBS.errors as errors
 import MAGSBS.mparser as mp
 from MAGSBS.datastructures import Reference, Heading
 
+
 def parse_formulas(doc):
     """Tiny helper to call mp.parse_formulas."""
-    return mp.parse_formulas({1: doc.split('\n')})
-
+    return mp.parse_formulas({1: doc.split("\n")})
 
 
 class test_mparser(unittest.TestCase):
@@ -16,206 +17,228 @@ class test_mparser(unittest.TestCase):
     ##############################################################
     # extract_headings_from_par
     def test_that_an_underlined_h1_is_extracted(self):
-        pars = {1:['jo', '===']}
+        pars = {1: ["jo", "==="]}
         self.assertEqual(len(mp.extract_headings_from_par(pars)), 1)
 
     def test_that_an_underlined_h2_is_extracted(self):
-        pars = {1:['jo','---']}
+        pars = {1: ["jo", "---"]}
         self.assertEqual(len(mp.extract_headings_from_par(pars)), 1)
 
     def test_that_max_headings_is_used(self):
-        pars = {1:['jo','===='], 4:['##test']}
+        pars = {1: ["jo", "===="], 4: ["##test"]}
         self.assertEqual(len(mp.extract_headings_from_par(pars, 1)), 1)
 
     def test_that_headings_with_hashes_are_recognized(self):
-        pars = {1:['#h1'], 4:['##h2']}
+        pars = {1: ["#h1"], 4: ["##h2"]}
         self.assertEqual(len(mp.extract_headings_from_par(pars)), 2)
 
     ##############################################################
     # test extract_page_numbers_from_par
 
     def test_that_correct_pnum_is_recognized(self):
-        pnums = mp.extract_page_numbers_from_par({1:['|| - Seite 80 -']})
+        pnums = mp.extract_page_numbers_from_par({1: ["|| - Seite 80 -"]})
         self.assertEqual(len(pnums), 1, "exactly one page number is expected.")
         self.assertEqual(pnums[0].number, 80)
 
     def test_that_more_than_one_pnum_is_parsed_and_line_numbers_are_correct(self):
         pars = collections.OrderedDict()
-        pars[1] = ['|| - Seite 80 -']
-        pars[3] = ['|| Some text', 'hopefully ignored']
-        pars[5] = ['|| - Seite 81 -']
+        pars[1] = ["|| - Seite 80 -"]
+        pars[3] = ["|| Some text", "hopefully ignored"]
+        pars[5] = ["|| - Seite 81 -"]
         pnums = mp.extract_page_numbers_from_par(pars)
         self.assertEqual(len(pnums), 2)
         lnums = [pnum.line_no for pnum in pnums]
         self.assertTrue(1 in lnums and 5 in lnums)
 
-
     def test_that_incorrect_pnum_is_not_recognized(self):
-        pars = {1:['|| - alles fehlerhaft hier -']}
+        pars = {1: ["|| - alles fehlerhaft hier -"]}
         self.assertEqual(len(mp.extract_page_numbers_from_par(pars)), 0)
 
     def test_that_invalid_page_numbers_are_ignored(self):
-        pnums = mp.extract_page_numbers_from_par({1:['|| - Seite abc -']})
+        pnums = mp.extract_page_numbers_from_par({1: ["|| - Seite abc -"]})
         self.assertEqual(len(pnums), 0)
 
     def test_that_lower_case_page_identifiers_are_recognized(self):
-        pnums = mp.extract_page_numbers_from_par({999:['|| - seite 80 -']})
+        pnums = mp.extract_page_numbers_from_par({999: ["|| - seite 80 -"]})
         self.assertEqual(len(pnums), 1)
 
     def test_that_varying_spaces_are_not_an_issue(self):
-        pnums = mp.extract_page_numbers_from_par({1:['|| -Seite  80 -'],
-            7:['||  - Seite 80-']})
+        pnums = mp.extract_page_numbers_from_par(
+            {1: ["|| -Seite  80 -"], 7: ["||  - Seite 80-"]}
+        )
         self.assertEqual(len(pnums), 2)
 
     def test_that_roman_numbers_work(self):
-        pnums = mp.extract_page_numbers_from_par({1:['|| - Seite I -'],
-            7:['|| - Seite XVI -'], 20:['|| - Seite CCC -']})
+        pnums = mp.extract_page_numbers_from_par(
+            {1: ["|| - Seite I -"], 7: ["|| - Seite XVI -"], 20: ["|| - Seite CCC -"]}
+        )
         self.assertEqual(len(pnums), 3)
 
     def test_invalid_roman_numbers_trigger_exception(self):
-        pnums = mp.extract_page_numbers_from_par({1:['|| - Seite IIIIIVC -']})
+        pnums = mp.extract_page_numbers_from_par({1: ["|| - Seite IIIIIVC -"]})
         self.assertEqual(len(pnums), 0)
-
 
     ##############################################################
     # test file2paragraphs
     def test_that_a_simple_paragraph_is_recognized(self):
-        pars = mp.file2paragraphs(['Hallo Welt'])
+        pars = mp.file2paragraphs(["Hallo Welt"])
         self.assertEqual(len(pars), 1)
-        self.assertEqual(pars[1], ['Hallo Welt'])
+        self.assertEqual(pars[1], ["Hallo Welt"])
 
     def test_that_a_multiline_paragraph_is_recognized_correctly(self):
-        expected = ['Hallo','Welt']
-        actual = mp.file2paragraphs('\n'.join(expected))
+        expected = ["Hallo", "Welt"]
+        actual = mp.file2paragraphs("\n".join(expected))
         self.assertEqual(actual[1], expected)
 
     def test_that_multiple_paragraphs_are_recognized(self):
-        lines = 'Ich\nbin\n\nein\nTest'
-        result = mp.file2paragraphs(lines.split('\n'))
-        self.assertEqual(result[1], ['Ich', 'bin'])
-        self.assertEqual(result[4], ['ein','Test'])
+        lines = "Ich\nbin\n\nein\nTest"
+        result = mp.file2paragraphs(lines.split("\n"))
+        self.assertEqual(result[1], ["Ich", "bin"])
+        self.assertEqual(result[4], ["ein", "Test"])
 
     def test_that_lines_are_joined_and_line_numbers_are_correct(self):
-        content = '##bad\\\nexample\n\ndone'
+        content = "##bad\\\nexample\n\ndone"
         result = mp.file2paragraphs(content, join_lines=True)
         # paragraph after joined line starts with correct line number
         self.assertTrue(4 in result)
-        self.assertFalse('\\' in '\n'.join(result[1]))
+        self.assertFalse("\\" in "\n".join(result[1]))
 
     ##############################################################
     # get_chapter_number_from_path
     def test_continued_lines_in_hashed_headings_recognized(self):
-        headings = mp.headings.extract_headings_from_par(par(
-                "### a heading\\\nwhich is too long\n\ncontent\n"))
+        headings = mp.headings.extract_headings_from_par(
+            par("### a heading\\\nwhich is too long\n\ncontent\n")
+        )
         self.assertEqual(len(headings), 1)
-        self.assertEqual(headings[0].get_text(), 'a heading\nwhich is too long')
+        self.assertEqual(headings[0].get_text(), "a heading\nwhich is too long")
 
     def test_continued_lines_in_underlined_headings_work(self):
-        headings = mp.headings.extract_headings_from_par(par(
-                "a heading\\\nwhich is too long\n=====\n\ncontent\n"))
+        headings = mp.headings.extract_headings_from_par(
+            par("a heading\\\nwhich is too long\n=====\n\ncontent\n")
+        )
         self.assertEqual(len(headings), 1)
-        self.assertEqual(headings[0].get_text(), 'a heading\nwhich is too long')
-        headings = mp.headings.extract_headings_from_par(par(
-                "a heading\\\nwhich is too long\\\ntest\n-----\n\ncontent\n"))
+        self.assertEqual(headings[0].get_text(), "a heading\nwhich is too long")
+        headings = mp.headings.extract_headings_from_par(
+            par("a heading\\\nwhich is too long\\\ntest\n-----\n\ncontent\n")
+        )
         self.assertEqual(len(headings), 1)
-        self.assertEqual(headings[0].get_text(),
-                'a heading\nwhich is too long\ntest')
+        self.assertEqual(headings[0].get_text(), "a heading\nwhich is too long\ntest")
 
     ############################################################################
     # tests for compute_position()
 
     def test_that_position_for_formula_at_beginning_of_document_is_correct(self):
-        self.assertEqual(mp.compute_position(''), 1)
-        self.assertEqual(mp.compute_position('', 1), 1)
+        self.assertEqual(mp.compute_position(""), 1)
+        self.assertEqual(mp.compute_position("", 1), 1)
 
     def test_that_pos_for_formula_on_first_line_correct(self):
-        self.assertEqual(mp.compute_position('abc'), 4)
+        self.assertEqual(mp.compute_position("abc"), 4)
 
     def test_that_pos_after_line_berak_is_correct(self):
-        self.assertEqual(mp.compute_position('a\nb\ncd'), 3)
+        self.assertEqual(mp.compute_position("a\nb\ncd"), 3)
 
     def test_that_offset_is_ignored_if_line_break_present(self):
-        self.assertEqual(mp.compute_position('a\ncd', 99), 3)
-
+        self.assertEqual(mp.compute_position("a\ncd", 99), 3)
 
     ############################################################################
     # tests of parse_environments
 
     def test_that_normal_text_does_not_contain_formulas(self):
-        self.assertFalse(mp.parse_environments('This is \na bit of\n Text'))
+        self.assertFalse(mp.parse_environments("This is \na bit of\n Text"))
 
     def test_that_escaped_dollars_are_ignored(self):
-        self.assertFalse(mp.parse_environments(r'It has \$\$been\$\$ escaped'))
+        self.assertFalse(mp.parse_environments(r"It has \$\$been\$\$ escaped"))
 
     def test_one_formula_per_line_works(self):
-        formulas = mp.parse_environments('Here is $$\\tau$$.')
+        formulas = mp.parse_environments("Here is $$\\tau$$.")
         self.assertEqual(len(list(formulas.keys())), 1)
-        self.assertTrue(r'\tau' in formulas.values(), "expected \\tau, found: "
-                + repr(formulas.values()))
+        self.assertTrue(
+            r"\tau" in formulas.values(),
+            "expected \\tau, found: " + repr(formulas.values()),
+        )
 
     def test_that_two_formulas_per_line_are_recognized(self):
-        formulas = mp.parse_environments('Here is $$\\tau$$ and $$\\pi$$.')
-        self.assertEqual(len(formulas.keys()), 2, "expected two formulas, got " + repr(formulas))
-        self.assertTrue('\\tau' in formulas.values())
-        self.assertTrue('\\pi' in formulas.values())
+        formulas = mp.parse_environments("Here is $$\\tau$$ and $$\\pi$$.")
+        self.assertEqual(
+            len(formulas.keys()), 2, "expected two formulas, got " + repr(formulas)
+        )
+        self.assertTrue("\\tau" in formulas.values())
+        self.assertTrue("\\pi" in formulas.values())
 
     def test_that_two_formulas_per_line_have_correct_pos(self):
-        formulas = mp.parse_environments('Here is $$\\tau$$ and $$\\pi$$.')
-        self.assertTrue((1, 9) in formulas,
-                "expected (1,9) as position, found " + repr(formulas.keys()))
-        self.assertTrue((1, 22) in formulas,
-                "expected (1,22) as position, found " + repr(formulas.keys()))
+        formulas = mp.parse_environments("Here is $$\\tau$$ and $$\\pi$$.")
+        self.assertTrue(
+            (1, 9) in formulas,
+            "expected (1,9) as position, found " + repr(formulas.keys()),
+        )
+        self.assertTrue(
+            (1, 22) in formulas,
+            "expected (1,22) as position, found " + repr(formulas.keys()),
+        )
 
     def test_that_multiline_environments_have_correct_pos(self):
-        formulas = mp.parse_environments('j$$a\nb$$,\n$$c$$')
-        self.assertTrue((1, 2) in formulas.keys(), "expected (1, 2) to be in the " +
-                "list of formulas, got " + repr(formulas))
+        formulas = mp.parse_environments("j$$a\nb$$,\n$$c$$")
+        self.assertTrue(
+            (1, 2) in formulas.keys(),
+            "expected (1, 2) to be in the " + "list of formulas, got " + repr(formulas),
+        )
         self.assertTrue((3, 1) in formulas.keys())
         # the same with the second environment slightly shiftet
-        formulas = mp.parse_environments('j$$a\nb$$,\nchar$$c$$')
-        self.assertTrue((1, 2) in formulas.keys(), "expected (1, 2) to be in the " +
-                "list of formulas, got " + repr(formulas))
+        formulas = mp.parse_environments("j$$a\nb$$,\nchar$$c$$")
+        self.assertTrue(
+            (1, 2) in formulas.keys(),
+            "expected (1, 2) to be in the " + "list of formulas, got " + repr(formulas),
+        )
         self.assertTrue((3, 5) in formulas.keys())
 
     def test_that_three_environments_per_line_work(self):
-        formulas = mp.parse_environments("u\nok $$first$$, then $$second$$ and in the end $$third$$.")
+        formulas = mp.parse_environments(
+            "u\nok $$first$$, then $$second$$ and in the end $$third$$."
+        )
         self.assertTrue((2, 4) in formulas)
         self.assertTrue((2, 20) in formulas)
         self.assertTrue((2, 46) in formulas)
 
+
 ################################################################################
+
 
 class TestParseFormulas(unittest.TestCase):
     def test_all_formula_types_recognized(self):
-        formulas = parse_formulas('test $first$ and $$second$$')
+        formulas = parse_formulas("test $first$ and $$second$$")
         self.assertEqual(len(formulas.keys()), 2)
         self.assertTrue((1, 6) in formulas)
         self.assertTrue((1, 18) in formulas)
 
     def test_positions_of_formulas_are_exact(self):
-        formulas = parse_formulas('test $first$ and $$second$$ $third$')
+        formulas = parse_formulas("test $first$ and $$second$$ $third$")
         self.assertEqual(len(formulas.keys()), 3)
         self.assertTrue((1, 6) in formulas)
         self.assertTrue((1, 18) in formulas)
-        self.assertTrue((1, 29) in formulas, "expected (1,29) to exist, got " +
-                repr(list(formulas.keys())))
-        self.assertTrue('third' in formulas.values(), "'third' expected i" +
-                "in formulas; found: " + repr(formulas.values()))
+        self.assertTrue(
+            (1, 29) in formulas,
+            "expected (1,29) to exist, got " + repr(list(formulas.keys())),
+        )
+        self.assertTrue(
+            "third" in formulas.values(),
+            "'third' expected i" + "in formulas; found: " + repr(formulas.values()),
+        )
 
     def test_positions_of_formulas_are_correct_with_line_breaks(self):
-        formulas = parse_formulas('test \n$first$ an\nd $$second$$ $third$')
+        formulas = parse_formulas("test \n$first$ an\nd $$second$$ $third$")
         self.assertEqual(len(formulas.keys()), 3)
         self.assertTrue((2, 1) in formulas)
         self.assertTrue((3, 3) in formulas)
-        self.assertTrue((3, 14) in formulas,
-                "in formulas; found: " + repr(formulas.keys()))
+        self.assertTrue(
+            (3, 14) in formulas, "in formulas; found: " + repr(formulas.keys())
+        )
 
     def test_that_formulas_are_in_correct_order(self):
-        formulas = parse_formulas('test \n$first$ an\nd $$second$$ $third$')
-        self.assertEqual(list(formulas.values()), ['first', 'second', 'third'])
+        formulas = parse_formulas("test \n$first$ an\nd $$second$$ $third$")
+        self.assertEqual(list(formulas.values()), ["first", "second", "third"])
 
     def test_that_multiple_paragraphs_are_parsed_correctly(self):
-        pars = {1: ['hi', '$foo$ and $bar$'], 4: ['$$gamma$$ and $$beta$$']}
+        pars = {1: ["hi", "$foo$ and $bar$"], 4: ["$$gamma$$ and $$beta$$"]}
         formulas = mp.parse_formulas(pars)
         self.assertTrue((2, 1) in formulas)
         self.assertTrue((2, 11) in formulas)
@@ -227,114 +250,149 @@ class TestParseFormulas(unittest.TestCase):
 
 # flatten a list
 flatten = lambda x: list(itertools.chain.from_iterable(x))
-seralize_doc = lambda x: '\n'.join(flatten(x.values()))
+seralize_doc = lambda x: "\n".join(flatten(x.values()))
+
 
 def parcdblk(string):
     """Get a paragraph dictionary with code block already removed."""
-    return mp.rm_codeblocks(
-            mp.file2paragraphs(string.split('\n')))
+    return mp.rm_codeblocks(mp.file2paragraphs(string.split("\n")))
+
 
 def par(string):
     """Transform a string (with paragraphs into a paragraph dictionary."""
-    return mp.file2paragraphs(string.split('\n'))
+    return mp.file2paragraphs(string.split("\n"))
+
 
 def format_ln(line, lines):
     """Format error message, see usage for explanation."""
     return "expected paragraph starting at line {}, but doesn't exist; got: {}".format(
-            line, ', '.join(map(str, lines)))
+        line, ", ".join(map(str, lines))
+    )
 
 
 class TestCodeBlockRemoval(unittest.TestCase):
     def test_that_normal_paragraphs_are_untouched(self):
-        data = parcdblk('ja\nso\nist\nes\n\n\nok\nhier\npassiert\nnichts')
+        data = parcdblk("ja\nso\nist\nes\n\n\nok\nhier\npassiert\nnichts")
         self.assertTrue(1 in data, format_ln(1, data.keys()))
         self.assertTrue(7 in data, format_ln(7, data.keys()))
 
     def test_that_tilde_code_blocks_at_beginning_and_end_are_removed(self):
-        data = parcdblk('~~~~\nsome_code\nok\n~~~~\n\nla\nle\nlu\n\n~~~~\nmore_code\nb\n~~~~\n')
-        self.assertFalse('some_code' in '\n'.join(flatten(data.values())))
+        data = parcdblk(
+            "~~~~\nsome_code\nok\n~~~~\n\nla\nle\nlu\n\n~~~~\nmore_code\nb\n~~~~\n"
+        )
+        self.assertFalse("some_code" in "\n".join(flatten(data.values())))
         self.assertTrue(6 in data, format_ln(6, data.keys()))
-        self.assertFalse('more_code' in '\n'.join(flatten(data.values())))
+        self.assertFalse("more_code" in "\n".join(flatten(data.values())))
 
     def test_tilde_that_code_blocks_in_the_middle_work(self):
-        data = parcdblk('heading\n======\n\ndum-\nmy\n\n~~~~\nremoved\n~~~~\n\ntest\ndone\n')
-        self.assertFalse('removed' in '\n'.join(flatten(data.values())))
+        data = parcdblk(
+            "heading\n======\n\ndum-\nmy\n\n~~~~\nremoved\n~~~~\n\ntest\ndone\n"
+        )
+        self.assertFalse("removed" in "\n".join(flatten(data.values())))
         # code block exists and is empty
         self.assertTrue(7 in data, format_ln(7, data.keys()))
-        self.assertEqual(''.join(flatten(data[7])).strip(), '',
-                "The code block in the middle should be empty; document is: " \
-                    + repr(data))
+        self.assertEqual(
+            "".join(flatten(data[7])).strip(),
+            "",
+            "The code block in the middle should be empty; document is: " + repr(data),
+        )
 
     def test_backprime_tilde_code_blocks_at_beginning_and_end_are_removed(self):
-        data = parcdblk('```\nsome_code\nok\n```\n\nla\nle\nlu\n\n```\nmore_code\nb\n```\n')
-        self.assertFalse('some_code' in '\n'.join(flatten(data.values())))
+        data = parcdblk(
+            "```\nsome_code\nok\n```\n\nla\nle\nlu\n\n```\nmore_code\nb\n```\n"
+        )
+        self.assertFalse("some_code" in "\n".join(flatten(data.values())))
         self.assertTrue(6 in data, format_ln(6, data.keys()))
-        self.assertFalse('more_code' in '\n'.join(flatten(data.values())))
+        self.assertFalse("more_code" in "\n".join(flatten(data.values())))
 
     def test_backprime_that_code_blocks_in_the_middle_work(self):
-        data = parcdblk('heading\n======\n\ndum-\nmy\n\n```\nremoved\n```\n\ntest\ndone\n')
-        self.assertFalse('removed' in '\n'.join(flatten(data.values())))
+        data = parcdblk(
+            "heading\n======\n\ndum-\nmy\n\n```\nremoved\n```\n\ntest\ndone\n"
+        )
+        self.assertFalse("removed" in "\n".join(flatten(data.values())))
         # code block exists and is empty
         self.assertTrue(7 in data, format_ln(7, data.keys()))
-        self.assertEqual(''.join(flatten(data[7])).strip(), '',
-                "The code block in the middle should be empty; document is: " \
-                    + repr(data))
+        self.assertEqual(
+            "".join(flatten(data[7])).strip(),
+            "",
+            "The code block in the middle should be empty; document is: " + repr(data),
+        )
 
     def test_that_backprime_blocks_with_prg_language_are_removed(self):
-        data = parcdblk('```rust\nsome_code\nok\n```\n\nla\nle\nlu\n\n```\nmore_code\nb\n```\n')
-        self.assertFalse('some_code' in '\n'.join(flatten(data.values())))
+        data = parcdblk(
+            "```rust\nsome_code\nok\n```\n\nla\nle\nlu\n\n```\nmore_code\nb\n```\n"
+        )
+        self.assertFalse("some_code" in "\n".join(flatten(data.values())))
         self.assertTrue(6 in data, format_ln(6, data.keys()))
-        self.assertFalse('more_code' in '\n'.join(flatten(data.values())))
-
-
+        self.assertFalse("more_code" in "\n".join(flatten(data.values())))
 
     def test_that_indentedcode_blocks_at_beginning_and_end_are_removed(self):
-        data = parcdblk('\tsome_code\n\tok\n\nla\nle\nlu\n\n\tmore_code\n\tb\n')
-        self.assertFalse('some_code' in '\n'.join(flatten(data.values())))
+        data = parcdblk("\tsome_code\n\tok\n\nla\nle\nlu\n\n\tmore_code\n\tb\n")
+        self.assertFalse("some_code" in "\n".join(flatten(data.values())))
         self.assertTrue(4 in data, format_ln(6, data.keys()))
-        self.assertFalse('more_code' in '\n'.join(flatten(data.values())))
+        self.assertFalse("more_code" in "\n".join(flatten(data.values())))
 
     def test_that_indented_code_blocks_in_the_middle_work(self):
-        data = parcdblk('heading\n======\n\ndum-\nmy\n\n\tremoved\n\ntest\ndone\n')
-        self.assertFalse('removed' in '\n'.join(flatten(data.values())),
-                "code block should have been removed; document: " + repr(data))
+        data = parcdblk("heading\n======\n\ndum-\nmy\n\n\tremoved\n\ntest\ndone\n")
+        self.assertFalse(
+            "removed" in "\n".join(flatten(data.values())),
+            "code block should have been removed; document: " + repr(data),
+        )
         # code block exists and is empty
         self.assertTrue(7 in data, format_ln(7, data.keys()))
-        self.assertEqual(''.join(flatten(data[7])).strip(), '',
-                "The code block in the middle should be empty; document is: " \
-                    + repr(data))
+        self.assertEqual(
+            "".join(flatten(data[7])).strip(),
+            "",
+            "The code block in the middle should be empty; document is: " + repr(data),
+        )
 
     def test_that_indented_block_not_removed_if_itemize_before(self):
-        four_spaces = parcdblk('- some\n- list\n- items\n\n    this is part\n    of the last list item\n')
-        self.assertTrue('this is part' in seralize_doc(four_spaces),
-                "'this is part' was not found in document: " + repr(seralize_doc(four_spaces)))
-        self.assertTrue('of the last' in seralize_doc(four_spaces))
-        three_spaces = parcdblk('- some\n- list\n- items\n\n   this is part\n   of the last list item\n')
-        self.assertTrue('this is part' in seralize_doc(four_spaces) and
-                'of the last' in seralize_doc(four_spaces))
+        four_spaces = parcdblk(
+            "- some\n- list\n- items\n\n    this is part\n    of the last list item\n"
+        )
+        self.assertTrue(
+            "this is part" in seralize_doc(four_spaces),
+            "'this is part' was not found in document: "
+            + repr(seralize_doc(four_spaces)),
+        )
+        self.assertTrue("of the last" in seralize_doc(four_spaces))
+        three_spaces = parcdblk(
+            "- some\n- list\n- items\n\n   this is part\n   of the last list item\n"
+        )
+        self.assertTrue(
+            "this is part" in seralize_doc(four_spaces)
+            and "of the last" in seralize_doc(four_spaces)
+        )
 
-        one_tab = parcdblk('- some\n- list\n- items\n\n\tthis is part\n\tof the last list item\n')
-        self.assertTrue('this is part' in seralize_doc(one_tab) and
-                'of the last' in seralize_doc(one_tab))
+        one_tab = parcdblk(
+            "- some\n- list\n- items\n\n\tthis is part\n\tof the last list item\n"
+        )
+        self.assertTrue(
+            "this is part" in seralize_doc(one_tab)
+            and "of the last" in seralize_doc(one_tab)
+        )
 
     def test_that_even_indented_tilde_blocks_are_removed(self):
-        data = parcdblk('-  blah\n\n    ~~~~\n    ok, here we go\n    ~~~~\n\njup')
-        self.assertFalse('ok, here' in seralize_doc(data))
+        data = parcdblk("-  blah\n\n    ~~~~\n    ok, here we go\n    ~~~~\n\njup")
+        self.assertFalse("ok, here" in seralize_doc(data))
         self.assertTrue(7 in data)
 
     def test_multi_paragraph_code_works(self):
-        data = parcdblk('dummy\n\n~~~~\n1\n2\n3\n\n4\n5\n6\n~~~~\n\nflup\n')
-        self.assertEqual(data[1], ['dummy'])
+        data = parcdblk("dummy\n\n~~~~\n1\n2\n3\n\n4\n5\n6\n~~~~\n\nflup\n")
+        self.assertEqual(data[1], ["dummy"])
         self.assertTrue(3 in data)
         self.assertTrue(8 in data)
-        self.assertTrue(all(l == '' for l in data[8]))
+        self.assertTrue(all(l == "" for l in data[8]))
 
     def test_inine_in_a_paragraph_on_its_own_works(self):
-        data = parcdblk('test\n\n`<IP>:<port>`\n\nend\n')
+        data = parcdblk("test\n\n`<IP>:<port>`\n\nend\n")
         for start in (1, 3, 5):
-            self.assertTrue(start in data,
-                "Expected {} in data, but not found.  Got: ".format(start, data))
-        self.assertEqual(data[3][0].strip(), '')
+            self.assertTrue(
+                start in data,
+                "Expected {} in data, but not found.  Got: ".format(start, data),
+            )
+        self.assertEqual(data[3][0].strip(), "")
+
 
 #  ###########################################################################
 # test link extraction
@@ -350,171 +408,343 @@ class TestLinkParser(unittest.TestCase):
             # first test, if the number of results is as expected
             self.assertTrue(
                 len(outputs[i]) == len(result),
-                "{}: Returned list for string \"{}\" contains "
+                '{}: Returned list for string "{}" contains '
                 "({}) reference(s), but ({}) expected.".format(
-                    test_name, inputs[i], len(result), len(outputs[i])))
+                    test_name, inputs[i], len(result), len(outputs[i])
+                ),
+            )
             for j, reference in enumerate(result):
-                self.assertEqual(reference.type,
-                                 outputs[i][j].type)
-                self.assertEqual(reference.is_image,
-                                 outputs[i][j].is_image)
-                self.assertEqual(reference.is_footnote,
-                                 outputs[i][j].is_footnote)
+                self.assertEqual(reference.type, outputs[i][j].type)
+                self.assertEqual(reference.is_image, outputs[i][j].is_image)
+                self.assertEqual(reference.is_footnote, outputs[i][j].is_footnote)
                 self.assertEqual(reference.id, outputs[i][j].id)
-                self.assertEqual(reference.link,
-                                 outputs[i][j].link)
-                self.assertEqual(reference.line_number,
-                                 outputs[i][j].line_number)
+                self.assertEqual(reference.link, outputs[i][j].link)
+                self.assertEqual(reference.line_number, outputs[i][j].line_number)
 
     def test_parsing_inline_links(self):
         test_inputs = [
             "\nThis is an [inline link](/url), \n and here's [one with \n a "
-            "title](http://fsf.org \"click here for a good time!\").",
+            'title](http://fsf.org "click here for a good time!").',
             "[Write me!](mailto:sam@green.eggs.ham)",
             "[I'm an inline link](https://www.google.com)",
-            "[I'm inline with title](https://www.google.com"
-            " \"Google's Homepage\")"]
+            "[I'm inline with title](https://www.google.com" ' "Google\'s Homepage")',
+        ]
         test_outputs = [
-            [Reference(Reference.Type.INLINE, False, "inline link", "/url",
-                       False, 2),
-             Reference(Reference.Type.INLINE, False, "one with \n a title",
-                       "http://fsf.org", False, 3)],
-            [Reference(Reference.Type.INLINE, False, "Write me!",
-                       "mailto:sam@green.eggs.ham", False, 1)],
-            [Reference(Reference.Type.INLINE, False, "I'm an inline link",
-                       "https://www.google.com", False, 1)],
-            [Reference(Reference.Type.INLINE, False, "I'm inline with title",
-                       "https://www.google.com", False, 1)]
-            ]
+            [
+                Reference(
+                    Reference.Type.INLINE, False, "inline link", "/url", False, 2
+                ),
+                Reference(
+                    Reference.Type.INLINE,
+                    False,
+                    "one with \n a title",
+                    "http://fsf.org",
+                    False,
+                    3,
+                ),
+            ],
+            [
+                Reference(
+                    Reference.Type.INLINE,
+                    False,
+                    "Write me!",
+                    "mailto:sam@green.eggs.ham",
+                    False,
+                    1,
+                )
+            ],
+            [
+                Reference(
+                    Reference.Type.INLINE,
+                    False,
+                    "I'm an inline link",
+                    "https://www.google.com",
+                    False,
+                    1,
+                )
+            ],
+            [
+                Reference(
+                    Reference.Type.INLINE,
+                    False,
+                    "I'm inline with title",
+                    "https://www.google.com",
+                    False,
+                    1,
+                )
+            ],
+        ]
         self.make_comparison(test_inputs, test_outputs, "Inline links")
 
     def test_labeled_links(self):
         test_inputs = [
             "[I'm a reference-style link][Case-insensitive text]",
-            "![You can use numbers for reference - style link definitions][1]"]
+            "![You can use numbers for reference - style link definitions][1]",
+        ]
         test_outputs = [
-            [Reference(Reference.Type.IMPLICIT, False, "Case-insensitive text",
-                       is_footnote=False, line_number=1)],
-            [Reference(Reference.Type.IMPLICIT, True, "1", is_footnote=False,
-                       line_number=1)]
+            [
+                Reference(
+                    Reference.Type.IMPLICIT,
+                    False,
+                    "Case-insensitive text",
+                    is_footnote=False,
+                    line_number=1,
+                )
+            ],
+            [
+                Reference(
+                    Reference.Type.IMPLICIT, True, "1", is_footnote=False, line_number=1
+                )
+            ],
         ]
         self.make_comparison(test_inputs, test_outputs, "Labeled links")
 
     def test_reference_links(self):
         test_inputs = [
-            "[my label 1]: /foo/bar.html  \"My title, optional\"",
+            '[my label 1]: /foo/bar.html  "My title, optional"',
             "[my label 2]: /foo",
             "[my label 3]: http://fsf.org (The free software foundation)",
             "[my label 4]: /bar#Special  'A title in single quotes'",
             "[my label 5]: <http://foo.bar.baz>",
-            "\n[my label 6]: http://fsf.org \n\t\"The free sw foundation\""]
+            '\n[my label 6]: http://fsf.org \n\t"The free sw foundation"',
+        ]
         test_outputs = [
-            [Reference(Reference.Type.EXPLICIT, False, "my label 1",
-                       "/foo/bar.html", False, 1)],
-            [Reference(Reference.Type.EXPLICIT, False, "my label 2", "/foo",
-                       False, 1)],
-            [Reference(Reference.Type.EXPLICIT, False, "my label 3",
-                       "http://fsf.org", False, 1)],
-            [Reference(Reference.Type.EXPLICIT, False, "my label 4",
-                       "/bar#Special", False, 1)],
-            [Reference(Reference.Type.EXPLICIT, False, "my label 5",
-                       "http://foo.bar.baz", False, 1)],
-            [Reference(Reference.Type.EXPLICIT, False, "my label 6",
-                       "http://fsf.org", False, 2)]
+            [
+                Reference(
+                    Reference.Type.EXPLICIT,
+                    False,
+                    "my label 1",
+                    "/foo/bar.html",
+                    False,
+                    1,
+                )
+            ],
+            [Reference(Reference.Type.EXPLICIT, False, "my label 2", "/foo", False, 1)],
+            [
+                Reference(
+                    Reference.Type.EXPLICIT,
+                    False,
+                    "my label 3",
+                    "http://fsf.org",
+                    False,
+                    1,
+                )
+            ],
+            [
+                Reference(
+                    Reference.Type.EXPLICIT,
+                    False,
+                    "my label 4",
+                    "/bar#Special",
+                    False,
+                    1,
+                )
+            ],
+            [
+                Reference(
+                    Reference.Type.EXPLICIT,
+                    False,
+                    "my label 5",
+                    "http://foo.bar.baz",
+                    False,
+                    1,
+                )
+            ],
+            [
+                Reference(
+                    Reference.Type.EXPLICIT,
+                    False,
+                    "my label 6",
+                    "http://fsf.org",
+                    False,
+                    2,
+                )
+            ],
         ]
         self.make_comparison(test_inputs, test_outputs, "Reference links")
 
     def test_standalone_links(self):
         # standalone links are specific types of labeled links
-        test_inputs = [
-            "See [my website][].",
-            "[1]\n\![test][]\nabc ![test2] def"]
+        test_inputs = ["See [my website][].", "[1]\n\![test][]\nabc ![test2] def"]
         test_outputs = [
-            [Reference(Reference.Type.IMPLICIT, False, "my website",
-                       is_footnote=False, line_number=1)],
-            [Reference(Reference.Type.IMPLICIT, False, "1", is_footnote=False,
-                       line_number=1),
-             Reference(Reference.Type.IMPLICIT, False, "test",
-                       is_footnote=False, line_number=2),
-             Reference(Reference.Type.IMPLICIT, True, "test2",
-                       is_footnote=False, line_number=3)]
+            [
+                Reference(
+                    Reference.Type.IMPLICIT,
+                    False,
+                    "my website",
+                    is_footnote=False,
+                    line_number=1,
+                )
+            ],
+            [
+                Reference(
+                    Reference.Type.IMPLICIT,
+                    False,
+                    "1",
+                    is_footnote=False,
+                    line_number=1,
+                ),
+                Reference(
+                    Reference.Type.IMPLICIT,
+                    False,
+                    "test",
+                    is_footnote=False,
+                    line_number=2,
+                ),
+                Reference(
+                    Reference.Type.IMPLICIT,
+                    True,
+                    "test2",
+                    is_footnote=False,
+                    line_number=3,
+                ),
+            ],
         ]
         self.make_comparison(test_inputs, test_outputs, "Standalone links")
 
     def test_nested_inlines(self):
-        test_inputs = ["[![Bildbeschreibung](bilder/test.jpg)](bild.html#"
-                       "title-of-the-graphic)",
-                       "[ ![Bildbeschreib](bilder/bild1.PNG) ]"
-                       "(bilder.html#bildb)\n\n|| - Seite 4 - \nabc"
-                       "[www.schattauer.de](www.schatt.de)",
-                       "[^1]: [k05025](bilder.html#heading-1) asdsad"]
+        test_inputs = [
+            "[![Bildbeschreibung](bilder/test.jpg)](bild.html#" "title-of-the-graphic)",
+            "[ ![Bildbeschreib](bilder/bild1.PNG) ]"
+            "(bilder.html#bildb)\n\n|| - Seite 4 - \nabc"
+            "[www.schattauer.de](www.schatt.de)",
+            "[^1]: [k05025](bilder.html#heading-1) asdsad",
+        ]
         test_outputs = [
-            [Reference(Reference.Type.INLINE, False,
-                       "![Bildbeschreibung](bilder/test.jpg)",
-                       "bild.html#title-of-the-graphic", False, 1),
-             Reference(Reference.Type.INLINE, True, "Bildbeschreibung",
-                       "bilder/test.jpg", False, 1)],
-            [Reference(Reference.Type.INLINE, False,
-                       " ![Bildbeschreib](bilder/bild1.PNG) ",
-                       "bilder.html#bildb", False, 1),
-             Reference(Reference.Type.INLINE, True, "Bildbeschreib",
-                       "bilder/bild1.PNG", False, 1),
-             Reference(Reference.Type.INLINE, False, "www.schattauer.de",
-                       "www.schatt.de", False, 4)],
-            [Reference(Reference.Type.EXPLICIT, False, "^1",
-                       "[k05025](bilder.html#heading-1) asdsad", True, 1),
-             Reference(Reference.Type.INLINE, False,
-                       "k05025", "bilder.html#heading-1", False, 1)]
+            [
+                Reference(
+                    Reference.Type.INLINE,
+                    False,
+                    "![Bildbeschreibung](bilder/test.jpg)",
+                    "bild.html#title-of-the-graphic",
+                    False,
+                    1,
+                ),
+                Reference(
+                    Reference.Type.INLINE,
+                    True,
+                    "Bildbeschreibung",
+                    "bilder/test.jpg",
+                    False,
+                    1,
+                ),
+            ],
+            [
+                Reference(
+                    Reference.Type.INLINE,
+                    False,
+                    " ![Bildbeschreib](bilder/bild1.PNG) ",
+                    "bilder.html#bildb",
+                    False,
+                    1,
+                ),
+                Reference(
+                    Reference.Type.INLINE,
+                    True,
+                    "Bildbeschreib",
+                    "bilder/bild1.PNG",
+                    False,
+                    1,
+                ),
+                Reference(
+                    Reference.Type.INLINE,
+                    False,
+                    "www.schattauer.de",
+                    "www.schatt.de",
+                    False,
+                    4,
+                ),
+            ],
+            [
+                Reference(
+                    Reference.Type.EXPLICIT,
+                    False,
+                    "^1",
+                    "[k05025](bilder.html#heading-1) asdsad",
+                    True,
+                    1,
+                ),
+                Reference(
+                    Reference.Type.INLINE,
+                    False,
+                    "k05025",
+                    "bilder.html#heading-1",
+                    False,
+                    1,
+                ),
+            ],
         ]
         self.make_comparison(test_inputs, test_outputs, "Inline nested")
 
     def test_other_links(self):
         test_inputs = [
             "- [x] Finish changes\n[ ] Push my commits to GitHub",
-            "<div><div id=\"my_ID\"/><span></span></div><span/>"
-            "<DiV><DIV id=\"my_id2\"><SPAN>[tEst](#TesT)</SPAN></DiV><SPAN/>",
+            '<div><div id="my_ID"/><span></span></div><span/>'
+            '<DiV><DIV id="my_id2"><SPAN>[tEst](#TesT)</SPAN></DiV><SPAN/>',
             "Seiten: [[15]](#seite-15--),\n [[20]](#seite-20--)",
             " \[RT\], errors) or biological (electromyographic \[EMG\]",
             "[a\[], [\]], [\[\]] and \n[](\])",
             "[po\\\[abc\\\][d]kus\](normal)",
             "\![image](google.jpg)",
-            r"\\[this\\\[this not\]\\]"
-            ]
+            r"\\[this\\\[this not\]\\]",
+        ]
         test_outputs = [
             [],
-            [Reference(Reference.Type.INLINE, False, "tEst", "#TesT", False,
-                       1)],
-            [Reference(Reference.Type.INLINE, False, "[15]", "#seite-15--",
-                       False, 1),
-             Reference(Reference.Type.IMPLICIT, False, "15", None, False, 1),
-             Reference(Reference.Type.INLINE, False, "[20]", "#seite-20--",
-                       False, 2),
-             Reference(Reference.Type.IMPLICIT, False, "20", None, False, 2)],
+            [Reference(Reference.Type.INLINE, False, "tEst", "#TesT", False, 1)],
+            [
+                Reference(
+                    Reference.Type.INLINE, False, "[15]", "#seite-15--", False, 1
+                ),
+                Reference(Reference.Type.IMPLICIT, False, "15", None, False, 1),
+                Reference(
+                    Reference.Type.INLINE, False, "[20]", "#seite-20--", False, 2
+                ),
+                Reference(Reference.Type.IMPLICIT, False, "20", None, False, 2),
+            ],
             [],
-            [Reference(Reference.Type.IMPLICIT, False, "a\[", None, False, 1),
-             Reference(Reference.Type.IMPLICIT, False, "\]", None, False, 1),
-             Reference(Reference.Type.IMPLICIT, False, "\[\]", None, False, 1),
-             Reference(Reference.Type.INLINE, False, "", "\]", False, 2)],
-            [Reference(Reference.Type.IMPLICIT, False,
-                       "po\\\\[abc\\\\][d]kus\\](normal", None, False, 1),
-             Reference(Reference.Type.IMPLICIT, False, "d", None, False, 1)],
-            [Reference(Reference.Type.INLINE, False, "image", "google.jpg",
-                       False, 1)],
-            [Reference(Reference.Type.IMPLICIT, False, r"this\\\[this not\]\\",
-                       None, False, 1)]
-            ]
+            [
+                Reference(Reference.Type.IMPLICIT, False, "a\[", None, False, 1),
+                Reference(Reference.Type.IMPLICIT, False, "\]", None, False, 1),
+                Reference(Reference.Type.IMPLICIT, False, "\[\]", None, False, 1),
+                Reference(Reference.Type.INLINE, False, "", "\]", False, 2),
+            ],
+            [
+                Reference(
+                    Reference.Type.IMPLICIT,
+                    False,
+                    "po\\\\[abc\\\\][d]kus\\](normal",
+                    None,
+                    False,
+                    1,
+                ),
+                Reference(Reference.Type.IMPLICIT, False, "d", None, False, 1),
+            ],
+            [Reference(Reference.Type.INLINE, False, "image", "google.jpg", False, 1)],
+            [
+                Reference(
+                    Reference.Type.IMPLICIT,
+                    False,
+                    r"this\\\[this not\]\\",
+                    None,
+                    False,
+                    1,
+                )
+            ],
+        ]
         self.make_comparison(test_inputs, test_outputs, "Other links")
 
     def test_line_nums(self):
         test_inputs = [
-            "\n[second]\n![third][]\n\n[fif\nth](k01.md)\nab [second]: k07.md"]
+            "\n[second]\n![third][]\n\n[fif\nth](k01.md)\nab [second]: k07.md"
+        ]
         test_outputs = [
-            [Reference(Reference.Type.IMPLICIT, False, "second", "", False, 2),
-             Reference(Reference.Type.IMPLICIT, True, "third", "", False, 3),
-             Reference(Reference.Type.INLINE, False, "fif\nth", "k01.md",
-                       False, 5),
-             Reference(Reference.Type.EXPLICIT, False, "second", "k07.md",
-                       False, 7)]]
+            [
+                Reference(Reference.Type.IMPLICIT, False, "second", "", False, 2),
+                Reference(Reference.Type.IMPLICIT, True, "third", "", False, 3),
+                Reference(Reference.Type.INLINE, False, "fif\nth", "k01.md", False, 5),
+                Reference(Reference.Type.EXPLICIT, False, "second", "k07.md", False, 7),
+            ]
+        ]
         self.make_comparison(test_inputs, test_outputs, "Line numbers")
 
     def test_reference_footnotes(self):
@@ -522,18 +752,43 @@ class TestLinkParser(unittest.TestCase):
             "[^1]: [k05025](k0502.html#head-1) asdsad\nasdsad\n\nabc",
             "[^2]: not to be tested",
             "[^3]: test\n",
-            "![^extended]: http://fsf.org \n(Foundation)\n\nabc"]
+            "![^extended]: http://fsf.org \n(Foundation)\n\nabc",
+        ]
         test_outputs = [
-            [Reference(Reference.Type.EXPLICIT, False, "^1",
-                       "[k05025](k0502.html#head-1) asdsad\nasdsad", True, 1),
-             Reference(Reference.Type.INLINE, False, "k05025",
-                       "k0502.html#head-1", False, 1)],
-            [Reference(Reference.Type.EXPLICIT, False, "^2",
-                       "not to be tested", True, 1)],
-            [Reference(Reference.Type.EXPLICIT, False, "^3", "test\n", True,
-                       1)],
-            [Reference(Reference.Type.EXPLICIT, True, "^extended",
-                       "http://fsf.org \n(Foundation)", True, 1)]
+            [
+                Reference(
+                    Reference.Type.EXPLICIT,
+                    False,
+                    "^1",
+                    "[k05025](k0502.html#head-1) asdsad\nasdsad",
+                    True,
+                    1,
+                ),
+                Reference(
+                    Reference.Type.INLINE,
+                    False,
+                    "k05025",
+                    "k0502.html#head-1",
+                    False,
+                    1,
+                ),
+            ],
+            [
+                Reference(
+                    Reference.Type.EXPLICIT, False, "^2", "not to be tested", True, 1
+                )
+            ],
+            [Reference(Reference.Type.EXPLICIT, False, "^3", "test\n", True, 1)],
+            [
+                Reference(
+                    Reference.Type.EXPLICIT,
+                    True,
+                    "^extended",
+                    "http://fsf.org \n(Foundation)",
+                    True,
+                    1,
+                )
+            ],
         ]
         self.make_comparison(test_inputs, test_outputs, "Footnote links")
 
@@ -542,32 +797,40 @@ class TestLinkParser(unittest.TestCase):
             "Formula (e.g. $\sqrt[5]{8547799037)}$.",
             "$$ blok formula [no] [detection](test) \n nor [ref]:abc.com $$",
             "\$ there is [formula] \$",
-            "\$ not even in [link \$ test]: reference"
+            "\$ not even in [link \$ test]: reference",
         ]
         test_outputs = [
             [],
             [],
-            [Reference(Reference.Type.IMPLICIT, False, "formula", "",
-                       False, 1)],
-            [Reference(Reference.Type.EXPLICIT, False, "link \$ test",
-                       "reference", False, 1)]
+            [Reference(Reference.Type.IMPLICIT, False, "formula", "", False, 1)],
+            [
+                Reference(
+                    Reference.Type.EXPLICIT,
+                    False,
+                    "link \$ test",
+                    "reference",
+                    False,
+                    1,
+                )
+            ],
         ]
         self.make_comparison(test_inputs, test_outputs, "Formula links")
 
     def test_todolist(self):
         test_inputs = [
             "     [ ]",
-            "-  \t  [ ] First:\n\t-\t[ ] Second\n\t-  [x] Filled"]
+            "-  \t  [ ] First:\n\t-\t[ ] Second\n\t-  [x] Filled",
+        ]
         test_outputs = [[], []]
 
         self.make_comparison(test_inputs, test_outputs, "ToDo links")
+
 
 #  ###########################################################################
 # test id detection
 
 
 class TestElementsIdsExtractor(unittest.TestCase):
-
     @staticmethod
     def out_msg(message):
         return "Result is {}".format(message)
@@ -575,31 +838,32 @@ class TestElementsIdsExtractor(unittest.TestCase):
     def test_long_entry(self):
         res = mp.get_html_elements_identifiers(
             "<div id=\"first\"></div><div id='second'>something <div>\n"
-            "<span id=\"3\">\n\n</span>")
+            '<span id="3">\n\n</span>'
+        )
         self.assertEqual(res, {"first", "second", "3"}, msg=self.out_msg(res))
 
     def test_short_entry(self):
-        res = mp.get_html_elements_identifiers(
-            "<div id=\"1\"/><span id='2_nd'/>")
+        res = mp.get_html_elements_identifiers("<div id=\"1\"/><span id='2_nd'/>")
         self.assertEqual(res, {"1", "2_nd"}, msg=self.out_msg(res))
 
     def test_no_id_entry(self):
         res = mp.get_html_elements_identifiers(
-            "<div></div><div/><span></span></span><div id=\"\"/>"
-            "<span id=''></span>")
+            '<div></div><div/><span></span></span><div id=""/>' "<span id=''></span>"
+        )
         self.assertEqual(res, set(), msg=self.out_msg(res))
 
     def test_more_attributes(self):
         res = mp.get_html_elements_identifiers(
             "<div class=\"test\" id=\"1\"/><span id='2_nd' test='test'/>"
-            "<span middle='2_nd' id=\"middle\" test='test'/>")
+            "<span middle='2_nd' id=\"middle\" test='test'/>"
+        )
         self.assertEqual(res, {"1", "2_nd", "middle"}, msg=self.out_msg(res))
+
 
 #  ###########################################################################
 
 
 class TestUnnumberedHeadings(unittest.TestCase):
-
     @staticmethod
     def out_msg(heading):
         return "Unnumbered detection failed for heading {}".format(heading)
@@ -612,12 +876,19 @@ class TestUnnumberedHeadings(unittest.TestCase):
 
     def test_head_label(self):
         test_cases = [
-            "H 1 {.unnumbered}", "H2\t\t\\\{-}", "H3  {-", "H4 {-}",
+            "H 1 {.unnumbered}",
+            "H2\t\t\\\{-}",
+            "H3  {-",
+            "H4 {-}",
             "H5 {.class .unnumbered .different}",
-            "H6 {# .differentclass .unnumbered}", "H7 {unnumbered}",
-            "H8 {# .different .unnumbered}", r"H9 \\{#id .unnumbered key=val}",
-            "H12 identifiers in HTML", "[HTML], [S5], or [RTF]?",
-            "3. Applications"]
+            "H6 {# .differentclass .unnumbered}",
+            "H7 {unnumbered}",
+            "H8 {# .different .unnumbered}",
+            r"H9 \\{#id .unnumbered key=val}",
+            "H12 identifiers in HTML",
+            "[HTML], [S5], or [RTF]?",
+            "3. Applications",
+        ]
         # cases, which generate different identificators than pandoc
         # format: test_case -> result (expected result)
         # "H10  {}  {-}" -> "h10-" ("h10")
@@ -626,11 +897,20 @@ class TestUnnumberedHeadings(unittest.TestCase):
         #       ("h11-.class-.unnumbered")
         # "*Dogs*?--in *my* house?" -> "dogs--in-my-house" ("dogsin-my-house")
 
-        outputs = ["h-1", "h2-", "h3--", "h4",
-                   "h5", "h6-.differentclass-.unnumbered",
-                   "h7-unnumbered", "h8-.different-.unnumbered", "id",
-                   "h12-identifiers-in-html",
-                   "html-s5-or-rtf", "applications"]
+        outputs = [
+            "h-1",
+            "h2-",
+            "h3--",
+            "h4",
+            "h5",
+            "h6-.differentclass-.unnumbered",
+            "h7-unnumbered",
+            "h8-.different-.unnumbered",
+            "id",
+            "h12-identifiers-in-html",
+            "html-s5-or-rtf",
+            "applications",
+        ]
 
         for i, case in enumerate(test_cases):
             heading = Heading(case, 0)
@@ -641,12 +921,14 @@ class TestUnnumberedHeadings(unittest.TestCase):
             self.assertTrue(self.get_res(case), self.out_msg(case))
 
     def test_unnumbered(self):
-        test_cases = ["# Heading 1 {.unnumbered}",
-                      "# Heading 1 {#id .unnumbered}",
-                      "## Heading 2\t\t{-}",
-                      "# Heading {-}",
-                      "### Heading {} {-}",
-                      "# Heading {#id .unnumbered .differentclass}",
-                      "# Heading {#id .differentclass .unnumbered }"]
+        test_cases = [
+            "# Heading 1 {.unnumbered}",
+            "# Heading 1 {#id .unnumbered}",
+            "## Heading 2\t\t{-}",
+            "# Heading {-}",
+            "### Heading {} {-}",
+            "# Heading {#id .unnumbered .differentclass}",
+            "# Heading {#id .differentclass .unnumbered }",
+        ]
         for case in test_cases:
             self.assertFalse(self.get_res(case), self.out_msg(case))

--- a/tests/test_pagenumbering.py
+++ b/tests/test_pagenumbering.py
@@ -1,5 +1,6 @@
 import unittest, sys
-sys.path.insert(0, '.') # just in case
+
+sys.path.insert(0, ".")  # just in case
 import os
 
 import MAGSBS
@@ -16,6 +17,7 @@ def mkpnum(line, num, arabic=True):
     p = MAGSBS.datastructures.PageNumber("Slide", num, is_arabic=arabic)
     p.line_no = num
     return p
+
 
 class test_add_pagenumber(unittest.TestCase):
 
@@ -51,32 +53,48 @@ class TestCheckPageNumbering(unittest.TestCase):
         pnums = [mkpnum(1, 1), mkpnum(3, 2), mkpnum(5, 3), mkpnum(20, 4)]
         self.assertEqual(pagenumbering.check_page_numbering(pnums), [])
         # roman numbers
-        pnums = [mkpnum(1, 1, False), mkpnum(3, 2, False),
-                mkpnum(5, 3, False), mkpnum(20, 4, False)]
+        pnums = [
+            mkpnum(1, 1, False),
+            mkpnum(3, 2, False),
+            mkpnum(5, 3, False),
+            mkpnum(20, 4, False),
+        ]
         self.assertEqual(pagenumbering.check_page_numbering(pnums), [])
 
     def test_starting_at_arbitrary_number_works(self):
         pnums = [mkpnum(1, 10), mkpnum(3, 11), mkpnum(5, 12), mkpnum(20, 13)]
         self.assertEqual(pagenumbering.check_page_numbering(pnums), [])
         # roman numbers
-        pnums = [mkpnum(1, 10, False), mkpnum(3, 11, False), mkpnum(5, 12, False),
-                mkpnum(20, 13, False)]
+        pnums = [
+            mkpnum(1, 10, False),
+            mkpnum(3, 11, False),
+            mkpnum(5, 12, False),
+            mkpnum(20, 13, False),
+        ]
         self.assertEqual(pagenumbering.check_page_numbering(pnums), [])
 
     def test_jumps_are_not_tolerated(self):
         pnums = [mkpnum(1, 10), mkpnum(3, 11), mkpnum(5, 12), mkpnum(20, 19)]
         self.assertNotEqual(pagenumbering.check_page_numbering(pnums), [])
         # roman numbers
-        pnums = [mkpnum(1, 10, False), mkpnum(3, 11, False), mkpnum(5, 12, False),
-                mkpnum(20, 18, False)]
+        pnums = [
+            mkpnum(1, 10, False),
+            mkpnum(3, 11, False),
+            mkpnum(5, 12, False),
+            mkpnum(20, 18, False),
+        ]
         self.assertNotEqual(pagenumbering.check_page_numbering(pnums), [])
 
     def test_all_numbers_after_errneous_are_reported(self):
         pnums = [mkpnum(1, 2), mkpnum(3, 11), mkpnum(5, 12), mkpnum(20, 19)]
         self.assertEqual(len(pagenumbering.check_page_numbering(pnums)), 3)
         # roman numbers
-        pnums = [mkpnum(1, 2, False), mkpnum(3, 11, False), mkpnum(5, 12, False),
-                mkpnum(20, 18, False)]
+        pnums = [
+            mkpnum(1, 2, False),
+            mkpnum(3, 11, False),
+            mkpnum(5, 12, False),
+            mkpnum(20, 18, False),
+        ]
         self.assertEqual(len(pagenumbering.check_page_numbering(pnums)), 3)
 
     def test_style_changes_are_correctly_handled(self):
@@ -84,8 +102,10 @@ class TestCheckPageNumbering(unittest.TestCase):
         pnums = [mkpnum(1, 10), mkpnum(3, 11), mkpnum(5, 99, False)]
         self.assertEqual(pagenumbering.check_page_numbering(pnums), [])
         # provoke error, continue normal
-        pnums = [mkpnum(1, 10), mkpnum(3, 22), mkpnum(5, 98, False),
-                mkpnum(20, 99, False)]
+        pnums = [
+            mkpnum(1, 10),
+            mkpnum(3, 22),
+            mkpnum(5, 98, False),
+            mkpnum(20, 99, False),
+        ]
         self.assertEqual(len(pagenumbering.check_page_numbering(pnums)), 1)
-       
-

--- a/tests/test_pandoc.py
+++ b/tests/test_pandoc.py
@@ -1,5 +1,5 @@
 # This file does NOT test pandoc, but MAGSBS.pandoc ;)
-#pylint: disable=too-many-public-methods,import-error,too-few-public-methods,missing-docstring,unused-variable,multiple-imports,invalid-name
+# pylint: disable=too-many-public-methods,import-error,too-few-public-methods,missing-docstring,unused-variable,multiple-imports,invalid-name
 import os, shutil, tempfile, unittest, json, pandocfilters
 from MAGSBS.config import MetaInfo
 import MAGSBS.datastructures as datastructures
@@ -7,32 +7,41 @@ import MAGSBS.errors as errors
 import MAGSBS.pandoc as pandoc
 
 # these are the already normalized keys of the MetaInfo enum
-META_DATA = {'Editor': 'unique1',
-        'SourceAuthor':'dummy',
-        'WorkingGroup':'unique2',
-        'Institution':'unique3',
-        'Source':'unique4',
-        'LectureTitle':'unique5',
-        'SemesterOfEdit':'unique1990',
-        'Language': 'de',
-        'path': 'None'}
+META_DATA = {
+    "Editor": "unique1",
+    "SourceAuthor": "dummy",
+    "WorkingGroup": "unique2",
+    "Institution": "unique3",
+    "Source": "unique4",
+    "LectureTitle": "unique5",
+    "SemesterOfEdit": "unique1990",
+    "Language": "de",
+    "path": "None",
+}
+
 
 def get_html_converter(meta_data=META_DATA, template=None):
-    h = pandoc.output_formats.html.HtmlConverter(meta_data, language='de')
+    h = pandoc.output_formats.html.HtmlConverter(meta_data, language="de")
     if template:
         h.template_copy = template
     h.setup()
     return h
 
+
 def get_epub_converter(meta_data=META_DATA):
-    h = pandoc.output_formats.epub.EpubConverter(meta_data, language='de')
+    h = pandoc.output_formats.epub.EpubConverter(meta_data, language="de")
     h.setup()
     return h
 
 
 def mkcache(file):
-    return datastructures.FileCache([('.', [os.path.dirname(file)], []),
-        (os.path.dirname(file), [], [os.path.basename(file)])])
+    return datastructures.FileCache(
+        [
+            (".", [os.path.dirname(file)], []),
+            (os.path.dirname(file), [], [os.path.basename(file)]),
+        ]
+    )
+
 
 class CleverTmpDir(tempfile.TemporaryDirectory):
     def __init__(self):
@@ -47,12 +56,13 @@ class CleverTmpDir(tempfile.TemporaryDirectory):
         os.chdir(self.cwd)
         super().__exit__(a, b, c)
 
+
 class test_HTMLConverter(unittest.TestCase):
     def setUp(self):
         self.original_directory = os.getcwd()
         self.tmpdir = tempfile.mkdtemp()
         os.chdir(self.tmpdir)
-        self.call_cleanup_on_me = None # used for the OutputFormatters
+        self.call_cleanup_on_me = None  # used for the OutputFormatters
 
     def tearDown(self):
         os.chdir(self.original_directory)
@@ -60,26 +70,26 @@ class test_HTMLConverter(unittest.TestCase):
         if self.call_cleanup_on_me:
             self.call_cleanup_on_me.cleanup()
 
-
     def test_that_css_information_is_in_template(self):
-        self.assertTrue('.underline' in get_html_converter().template_copy)
-        self.assertTrue('.frame' in get_html_converter().template_copy)
+        self.assertTrue(".underline" in get_html_converter().template_copy)
+        self.assertTrue(".frame" in get_html_converter().template_copy)
 
     def test_that_unsupported_formats_are_detected(self):
         with self.assertRaises(NotImplementedError):
-            pandoc.converter.Pandoc().get_formatter_for_format('mp4')
+            pandoc.converter.Pandoc().get_formatter_for_format("mp4")
 
     def test_that_all_meta_data_is_inserted_into_head(self):
-        h = pandoc.converter.Pandoc().get_formatter_for_format('html')
+        h = pandoc.converter.Pandoc().get_formatter_for_format("html")
         self.call_cleanup_on_me = h
         h.set_meta_data(META_DATA)
         data = h.get_template()
         for key, value in META_DATA.items():
-            if key == 'title' or key == 'language' or key == 'path':
-                continue # those don't need to be included
-            self.assertTrue(value in data,
-                    "%s (key=%s) not found in the template\n%s" % \
-                    (value, key, str(data)))
+            if key == "title" or key == "language" or key == "path":
+                continue  # those don't need to be included
+            self.assertTrue(
+                value in data,
+                "%s (key=%s) not found in the template\n%s" % (value, key, str(data)),
+            )
 
     def test_that_setup_writes_template(self):
         h = get_html_converter()
@@ -88,62 +98,63 @@ class test_HTMLConverter(unittest.TestCase):
 
     def test_title_is_contained_in_document(self):
         with CleverTmpDir():
-            path = os.path.join('k99', 'k99.md')
+            path = os.path.join("k99", "k99.md")
             os.mkdir(os.path.dirname(path))
-            with open(path, 'w', encoding='utf-8') as file:
+            with open(path, "w", encoding="utf-8") as file:
                 file.write("It works!\n=======\n\nbla\nblub\n")
             h = get_html_converter()
             h.convert([path], cache=mkcache(path))
-            with open(path.replace('.md', '.html')) as f:
+            with open(path.replace(".md", ".html")) as f:
                 data = f.read()
-            self.assertTrue('<title>It works!</title>' in data)
+            self.assertTrue("<title>It works!</title>" in data)
 
     def test_that_missing_key_raises_conf_error(self):
         meta = dict(META_DATA)
-        meta.pop('SourceAuthor')
+        meta.pop("SourceAuthor")
         self.assertRaises(errors.ConfigurationError, get_html_converter, meta)
 
     def test_that_language_is_set_in_body(self):
         meta = META_DATA.copy()
-        meta['Language'] = 'fr'
+        meta["Language"] = "fr"
         with CleverTmpDir():
-            path = os.path.join('k99', 'k99.md') # path within lecture
+            path = os.path.join("k99", "k99.md")  # path within lecture
             os.mkdir(os.path.dirname(path))
-            with open(path, 'w') as file:
-                file.write('It works!\n=========\n\nblah\nblub\n')
+            with open(path, "w") as file:
+                file.write("It works!\n=========\n\nblah\nblub\n")
             h = get_html_converter(meta)
             h.convert([path], cache=mkcache(path))
-            with open(path.replace('.md', '.html')) as f:
+            with open(path.replace(".md", ".html")) as f:
                 data = f.read()
-            bodypos = data.find('<body')
-            self.assertTrue('<body lang="fr"' in data or "<body lang='fr'" in data,
-                repr(data[bodypos:bodypos+250]))
+            bodypos = data.find("<body")
+            self.assertTrue(
+                '<body lang="fr"' in data or "<body lang='fr'" in data,
+                repr(data[bodypos : bodypos + 250]),
+            )
 
     def test_conentfilter_link_converter(self):
         """ast contains a link: 'target.md#target_id'.
         It should get converted to 'target.html#target_id'.
         """
         ast = {
-            "blocks":
-            [
-                {
-                    "t": "Link",
-                    "c": [["", [], []], [], ["target.md#target_id", ""]]
-                }
+            "blocks": [
+                {"t": "Link", "c": [["", [], []], [], ["target.md#target_id", ""]]}
             ]
         }
-        ast = pandocfilters.walk(ast, pandoc.contentfilter.html_link_converter, 'html', None)
+        ast = pandocfilters.walk(
+            ast, pandoc.contentfilter.html_link_converter, "html", None
+        )
         self.assertTrue("target.html#target_id" in json.dumps(ast))
 
 
 ################################################################################
+
 
 class test_EPUBConverter(unittest.TestCase):
     def setUp(self):
         self.original_directory = os.getcwd()
         self.tmpdir = tempfile.mkdtemp()
         os.chdir(self.tmpdir)
-        self.call_cleanup_on_me = None # used for the OutputFormatters
+        self.call_cleanup_on_me = None  # used for the OutputFormatters
 
     def tearDown(self):
         os.chdir(self.original_directory)
@@ -161,16 +172,14 @@ class test_EPUBConverter(unittest.TestCase):
         It should get converted to 'ch003.xhtml#target_id'.
         meta contains the key 'target_id' with the chapter number '3' as value."""
         ast = {
-            "blocks":
-            [
-                {
-                    "t": "Link",
-                    "c": [["", [], []], [], ["target.html#target_id", ""]]
-                }
+            "blocks": [
+                {"t": "Link", "c": [["", [], []], [], ["target.html#target_id", ""]]}
             ]
         }
-        meta = {'ids': {'target_id': 3}}
-        ast = pandocfilters.walk(ast, pandoc.contentfilter.epub_link_converter, 'epub', meta)
+        meta = {"ids": {"target_id": 3}}
+        ast = pandocfilters.walk(
+            ast, pandoc.contentfilter.epub_link_converter, "epub", meta
+        )
         self.assertTrue("ch003.xhtml#target_id" in json.dumps(ast))
 
     def test_conentfilter_convert_header_ids(self):
@@ -180,8 +189,7 @@ class test_EPUBConverter(unittest.TestCase):
         ast contains an image link with the id: 'image_id'.
         It should get converted to 'image_k03_image_id'."""
         ast = {
-            "blocks":
-            [
+            "blocks": [
                 {
                     "t": "Link",
                     "c": [
@@ -189,20 +197,19 @@ class test_EPUBConverter(unittest.TestCase):
                         [
                             {
                                 "t": "Image",
-                                "c": [["", [], []], [], ["k02/bilder/image.png", ""]]
+                                "c": [["", [], []], [], ["k02/bilder/image.png", ""]],
                             }
                         ],
-                        ["image#image_id", ""]
-                    ]
+                        ["image#image_id", ""],
+                    ],
                 },
-                {
-                    "t": "Header",
-                    "c": [1, ["header_id", [], []], []]
-                }
+                {"t": "Header", "c": [1, ["header_id", [], []], []]},
             ]
         }
         meta = "k03"
-        ast = pandocfilters.walk(ast, pandoc.contentfilter.epub_convert_header_ids, 'epub', meta)
+        ast = pandocfilters.walk(
+            ast, pandoc.contentfilter.epub_convert_header_ids, "epub", meta
+        )
         self.assertTrue("k03_header_id" in json.dumps(ast))
         self.assertTrue("image#image_k03_image_id" in json.dumps(ast))
 
@@ -210,16 +217,10 @@ class test_EPUBConverter(unittest.TestCase):
         """ast contains a header with the id: 'image_id'.
         It should get converted to 'image_image_id'.
         """
-        ast = {
-            "blocks":
-            [
-                {
-                    "t": "Header",
-                    "c": [1, ["image_id", [], []], []]
-                }
-            ]
-        }
-        ast = pandocfilters.walk(ast, pandoc.contentfilter.epub_convert_image_header_ids, 'epub', None)
+        ast = {"blocks": [{"t": "Header", "c": [1, ["image_id", [], []], []]}]}
+        ast = pandocfilters.walk(
+            ast, pandoc.contentfilter.epub_convert_image_header_ids, "epub", None
+        )
         self.assertTrue("image_image_id" in json.dumps(ast))
 
     def test_conentfilter_remove_images_from_toc(self):
@@ -230,52 +231,51 @@ class test_EPUBConverter(unittest.TestCase):
         It should get converted to
         '<p id=\\"header_id2\\" class=\\"header\\" data-level=\\"2\\">Text</p>'."""
         ast = {
-            "blocks":
-            [
+            "blocks": [
                 {
                     "t": "Header",
-                    "c": [1, ["header_id1", [], []], [{"t": "Str", "c": "Text"}]]
+                    "c": [1, ["header_id1", [], []], [{"t": "Str", "c": "Text"}]],
                 },
                 {
                     "t": "Header",
-                    "c": [2, ["header_id2", [], []], [{"t": "Str", "c": "Text"}]]
+                    "c": [2, ["header_id2", [], []], [{"t": "Str", "c": "Text"}]],
                 },
             ]
         }
-        ast = pandocfilters.walk(ast, pandoc.contentfilter.epub_remove_images_from_toc, 'epub', None)
-        self.assertTrue('<p id=\\"header_id2\\" class=\\"header\\" data-level=\\"2\\">Text</p>' in json.dumps(ast))
-        self.assertTrue('<p id=\\"header_id1\\" class=\\"header pagebreak\\" data-level=\\"1\\">Text</p>' in json.dumps(ast))
+        ast = pandocfilters.walk(
+            ast, pandoc.contentfilter.epub_remove_images_from_toc, "epub", None
+        )
+        self.assertTrue(
+            '<p id=\\"header_id2\\" class=\\"header\\" data-level=\\"2\\">Text</p>'
+            in json.dumps(ast)
+        )
+        self.assertTrue(
+            '<p id=\\"header_id1\\" class=\\"header pagebreak\\" data-level=\\"1\\">Text</p>'
+            in json.dumps(ast)
+        )
 
     def test_conentfilter_update_image_location(self):
         """meta conatins 'k03' which is used as prefix for URI.
         ast contains a image with path: 'image.png'.
         It should get converted to 'k03/image.png'."""
-        ast = {
-            "blocks":
-            [
-                {
-                    "t": "Image",
-                    "c": [["", [], []], [], ["image.png", ""]]
-                }
-            ]
-        }
+        ast = {"blocks": [{"t": "Image", "c": [["", [], []], [], ["image.png", ""]]}]}
         meta = "k03"
-        ast = pandocfilters.walk(ast, pandoc.contentfilter.epub_update_image_location, 'epub', meta)
+        ast = pandocfilters.walk(
+            ast, pandoc.contentfilter.epub_update_image_location, "epub", meta
+        )
         self.assertTrue("k03/image.png" in json.dumps(ast))
 
     def test_conentfilter_create_back_link_ids(self):
         """ast contains a link with the id: 'target_id'.
         It should get converted to 'target_id_back'."""
         ast = {
-            "blocks":
-            [
-                {
-                    "t": "Link",
-                    "c": [["", [], []], [], ["target.html#target_id", ""]]
-                }
+            "blocks": [
+                {"t": "Link", "c": [["", [], []], [], ["target.html#target_id", ""]]}
             ]
         }
-        ast = pandocfilters.walk(ast, pandoc.contentfilter.epub_create_back_link_ids, 'epub', None)
+        ast = pandocfilters.walk(
+            ast, pandoc.contentfilter.epub_create_back_link_ids, "epub", None
+        )
         self.assertTrue("target_id_back" in json.dumps(ast))
 
     def test_conentfilter_create_back_links(self):
@@ -284,20 +284,23 @@ class test_EPUBConverter(unittest.TestCase):
         The paragraph should contain the backlink with the target 'image_id_back'
         after the filter."""
         ast = {
-            "blocks":
-            [
+            "blocks": [
                 {
                     "t": "RawBlock",
                     "c": [
                         "html",
-                        "<p id=\"image_id\" class=\"header\" data-level=\"2\">Image</p>"
-                    ]
+                        '<p id="image_id" class="header" data-level="2">Image</p>',
+                    ],
                 }
             ]
         }
-        meta = {'ids': {'image_id_back': 3}}
-        ast = pandocfilters.walk(ast, pandoc.contentfilter.epub_create_back_links, 'epub', meta)
-        self.assertTrue('<a href=\\"ch003.xhtml#image_id_back\\">Image</a>' in json.dumps(ast))
+        meta = {"ids": {"image_id_back": 3}}
+        ast = pandocfilters.walk(
+            ast, pandoc.contentfilter.epub_create_back_links, "epub", meta
+        )
+        self.assertTrue(
+            '<a href=\\"ch003.xhtml#image_id_back\\">Image</a>' in json.dumps(ast)
+        )
 
     def test_conentfilter_collect_ids(self):
         """meta contains '{'chapter': 1, 'ids': {}}'.
@@ -305,62 +308,56 @@ class test_EPUBConverter(unittest.TestCase):
         'ids' should contain '{'image_id': 1, 'header_id': 2, 'target_id': 2}'
         after the filter."""
         ast = {
-            "blocks":
-            [
+            "blocks": [
                 {
                     "t": "RawBlock",
                     "c": [
                         "html",
-                        "<p id=\"image_id\" class=\"header\" data-level=\"2\">Image</p>"
-                    ]
+                        '<p id="image_id" class="header" data-level="2">Image</p>',
+                    ],
                 },
-                {
-                    "t": "Header",
-                    "c": [1, ["header_id", [], []], []]
-                },
+                {"t": "Header", "c": [1, ["header_id", [], []], []]},
                 {
                     "t": "Link",
-                    "c": [["target_id", [], []], [], ["target.html#target_id", ""]]
-                }
+                    "c": [["target_id", [], []], [], ["target.html#target_id", ""]],
+                },
             ]
         }
-        meta = {'chapter': 1, 'ids': {}}
-        ast = pandocfilters.walk(ast, pandoc.contentfilter.epub_collect_ids, 'epub', meta)
-        self.assertTrue(meta['chapter'] == 2)
-        self.assertTrue('image_id' in meta['ids'] and meta['ids']['image_id'] == 1)
-        self.assertTrue('header_id' in meta['ids'] and meta['ids']['header_id'] == 2)
-        self.assertTrue('target_id' in meta['ids'] and meta['ids']['target_id'] == 2)
+        meta = {"chapter": 1, "ids": {}}
+        ast = pandocfilters.walk(
+            ast, pandoc.contentfilter.epub_collect_ids, "epub", meta
+        )
+        self.assertTrue(meta["chapter"] == 2)
+        self.assertTrue("image_id" in meta["ids"] and meta["ids"]["image_id"] == 1)
+        self.assertTrue("header_id" in meta["ids"] and meta["ids"]["header_id"] == 2)
+        self.assertTrue("target_id" in meta["ids"] and meta["ids"]["target_id"] == 2)
 
     def test_conentfilter_unnumbered_toc(self):
         """ast contains a header with the id: 'header_id'.
         The class 'unnumbered' should be added to the ast.
         """
-        ast = {
-            "blocks":
-            [
-                {
-                    "t": "Header",
-                    "c": [1, ["header_id", [], []], []]
-                }
-            ]
-        }
-        ast = pandocfilters.walk(ast, pandoc.contentfilter.epub_unnumbered_toc, 'epub', None)
+        ast = {"blocks": [{"t": "Header", "c": [1, ["header_id", [], []], []]}]}
+        ast = pandocfilters.walk(
+            ast, pandoc.contentfilter.epub_unnumbered_toc, "epub", None
+        )
         self.assertTrue('["unnumbered"]' in json.dumps(ast))
 
 
 ################################################################################
 
+
 class TestNavbarGeneration(unittest.TestCase):
     def setUp(self):
-        self.files = (('.', ('anh01', 'v01', 'k01',), ('index.html',)),
-                ('anh01', [], ('anh01.md',)),
-                ('k01', (), ('k01.md',)),
-                ('v01', (), ('v01.md',))
-                )
+        self.files = (
+            (".", ("anh01", "v01", "k01",), ("index.html",)),
+            ("anh01", [], ("anh01.md",)),
+            ("k01", (), ("k01.md",)),
+            ("v01", (), ("v01.md",)),
+        )
         self.cache = datastructures.FileCache(self.files)
         self.pagenumbers = []
-        for i in range(1,50):
-            self.pagenumbers.append(datastructures.PageNumber('Seite', i))
+        for i in range(1, 50):
+            self.pagenumbers.append(datastructures.PageNumber("Seite", i))
 
         # set up test directory
         self.original_directory = os.getcwd()
@@ -370,63 +367,69 @@ class TestNavbarGeneration(unittest.TestCase):
             if not os.path.exists(d):
                 os.mkdir(d)
             for f in files:
-                with open(os.path.join(d, f), 'w') as file:
-                    file.write('\n')
+                with open(os.path.join(d, f), "w") as file:
+                    file.write("\n")
 
     def tearDown(self):
         os.chdir(self.original_directory)
         shutil.rmtree(self.tmpdir, ignore_errors=True)
 
-
-
     def gen_nav(self, path, cache=None, pnums=None, conf=None):
         h = get_html_converter()
-        pnums = (pnums if pnums else self.pagenumbers)
-        return h.generate_page_navigation(path,
-                (cache if cache else self.cache),
-                pnums,
-                conf=conf)
-
+        pnums = pnums if pnums else self.pagenumbers
+        return h.generate_page_navigation(
+            path, (cache if cache else self.cache), pnums, conf=conf
+        )
 
     def test_that_navbar_is_generated(self):
-        start,end = self.gen_nav('k01/k01.md')
+        start, end = self.gen_nav("k01/k01.md")
         self.assertTrue(start != None and end != None)
         self.assertTrue(isinstance(start, str) and isinstance(end, str))
 
     def test_that_pnum_gap_is_used(self):
-        conf = {MetaInfo.Language: 'de', MetaInfo.PageNumberingGap: 10}
-        start, end = self.gen_nav('k01/k01.md', conf=conf)
-        self.assertTrue('[5]' not in start+end) # links to page 5 don't exist
-        self.assertTrue('[10]' in start+end, # links to page 10 do exist
-                "page number 10 doesn't exist; got: " + repr(start))
+        conf = {MetaInfo.Language: "de", MetaInfo.PageNumberingGap: 10}
+        start, end = self.gen_nav("k01/k01.md", conf=conf)
+        self.assertTrue("[5]" not in start + end)  # links to page 5 don't exist
+        self.assertTrue(
+            "[10]" in start + end,  # links to page 10 do exist
+            "page number 10 doesn't exist; got: " + repr(start),
+        )
 
     def test_that_roman_numbers_work(self):
         h = get_html_converter()
-        pnums = [datastructures.PageNumber('page', i, is_arabic=False) for i in
-                range(1, 20)]
-        conf = {MetaInfo.Language : 'de', MetaInfo.PageNumberingGap: 5}
-        path = 'k01/k01.md' # that has been initilized in the setup method
-        start, end = h.generate_page_navigation(path, self.cache,
-            pnums, conf=conf)
-        self.assertTrue('[V]' in start+end,
-            "Expected page number V in output, but couldn't be found: " + repr(start))
+        pnums = [
+            datastructures.PageNumber("page", i, is_arabic=False) for i in range(1, 20)
+        ]
+        conf = {MetaInfo.Language: "de", MetaInfo.PageNumberingGap: 5}
+        path = "k01/k01.md"  # that has been initilized in the setup method
+        start, end = h.generate_page_navigation(path, self.cache, pnums, conf=conf)
+        self.assertTrue(
+            "[V]" in start + end,
+            "Expected page number V in output, but couldn't be found: " + repr(start),
+        )
 
     def test_that_language_is_used(self):
-        conf = {MetaInfo.Language: 'en', MetaInfo.PageNumberingGap: 5}
-        start, end = map(str.lower, self.gen_nav('k01/k01.md', conf=conf))
-        self.assertTrue('nhalt]' not in start+end)
-        self.assertTrue('table of contents]' in start+end)
+        conf = {MetaInfo.Language: "en", MetaInfo.PageNumberingGap: 5}
+        start, end = map(str.lower, self.gen_nav("k01/k01.md", conf=conf))
+        self.assertTrue("nhalt]" not in start + end)
+        self.assertTrue("table of contents]" in start + end)
 
     def test_that_link_to_next_file_if_missing_is_omitted(self):
-        start, end = self.gen_nav('anh01/anh01.md')
-        self.assertTrue('k01/k01.html' in start+end,
-                "previous chapter k01/k01.md not found; navbar: " + repr(start))
+        start, end = self.gen_nav("anh01/anh01.md")
+        self.assertTrue(
+            "k01/k01.html" in start + end,
+            "previous chapter k01/k01.md not found; navbar: " + repr(start),
+        )
         chapter_navigation = None
-        for chapter_navigation in start.split('\n'):
-            if chapter_navigation.endswith('inhalt.html)'):
+        for chapter_navigation in start.split("\n"):
+            if chapter_navigation.endswith("inhalt.html)"):
                 break
-        self.assertTrue(chapter_navigation != None,
-                ("A link to the next chapter should not exist, since there is "
+        self.assertTrue(
+            chapter_navigation != None,
+            (
+                "A link to the next chapter should not exist, since there is "
                 "none. However something makes this test believe that there is "
-                "actually another link. Here's the navigation bar: ") +
-                repr(start))
+                "actually another link. Here's the navigation bar: "
+            )
+            + repr(start),
+        )

--- a/tests/test_toc.py
+++ b/tests/test_toc.py
@@ -1,4 +1,4 @@
-#pylint: disable=too-many-public-methods,import-error,too-few-public-methods,missing-docstring,unused-variable
+# pylint: disable=too-many-public-methods,import-error,too-few-public-methods,missing-docstring,unused-variable
 import unittest
 import MAGSBS.datastructures
 import MAGSBS.toc as toc
@@ -10,21 +10,29 @@ def h(text, level, chapter=None):
         heading.set_chapter_number(chapter)
     return heading
 
+
 class test_factories(unittest.TestCase):
     ##############################################################
     # [heading] enumerater
     def test_that_chapters_are_enumerated_subsequently(self):
         c = toc.ChapterNumberEnumerator()
-        for i in range(1,11):
+        for i in range(1, 11):
             heading = h("stuff %d" % i, 1)
-            heading.set_chapter_number(i) # always a new chapter
+            heading.set_chapter_number(i)  # always a new chapter
             c.register(heading)
-            self.assertEqual(len(c.get_heading_enumeration()), 1, ("only level-one "
-                    "chapters should have been counted; got: {}"). \
-                        format(repr(c.get_heading_enumeration())))
-            self.assertEqual(c.get_heading_enumeration()[0], i, ("the enumerator "
-                            "should have counted to %d, but counted only to %d")\
-                                % (i, c.get_heading_enumeration()[0]))
+            self.assertEqual(
+                len(c.get_heading_enumeration()),
+                1,
+                ("only level-one " "chapters should have been counted; got: {}").format(
+                    repr(c.get_heading_enumeration())
+                ),
+            )
+            self.assertEqual(
+                c.get_heading_enumeration()[0],
+                i,
+                ("the enumerator " "should have counted to %d, but counted only to %d")
+                % (i, c.get_heading_enumeration()[0]),
+            )
 
     def test_that_sections_within_chapters_are_enumerated_subsequently(self):
         c = toc.ChapterNumberEnumerator()
@@ -32,30 +40,43 @@ class test_factories(unittest.TestCase):
         heading = h("absolute h1", 1, 1)
         c.register(heading)
         self.assertEqual(c.get_heading_enumeration(), [1])
-        for i in range(1,6):
+        for i in range(1, 6):
             heading = h("stuff %d" % i, 2, chapter=1)
             c.register(heading)
-            self.assertEqual(len(c.get_heading_enumeration()), 2, ("two level "
-                "should exist: chapter and section; got instead: {}").\
-                        format(repr(c.get_heading_enumeration())))
-            self.assertEqual(c.get_heading_enumeration(), [1, i], ("the enumerator "
-                            "should have counted to %d, but counted only to %d")\
-                                % (i, c.get_heading_enumeration()[0]))
+            self.assertEqual(
+                len(c.get_heading_enumeration()),
+                2,
+                (
+                    "two level " "should exist: chapter and section; got instead: {}"
+                ).format(repr(c.get_heading_enumeration())),
+            )
+            self.assertEqual(
+                c.get_heading_enumeration(),
+                [1, i],
+                ("the enumerator " "should have counted to %d, but counted only to %d")
+                % (i, c.get_heading_enumeration()[0]),
+            )
 
         # chapter 2
         heading = h("absolute h1", 1, 2)
         c.register(heading)
         self.assertEqual(c.get_heading_enumeration(), [2])
-        for i in range(1,6):
+        for i in range(1, 6):
             heading = h("stuff %d" % i, 2, chapter=2)
             c.register(heading)
-            self.assertEqual(len(c.get_heading_enumeration()), 2, ("two level "
-                "should exist: chapter and section; got instead: {}").\
-                        format(repr(c.get_heading_enumeration())))
-            self.assertEqual(c.get_heading_enumeration(), [2, i], ("the enumerator "
-                            "should have counted to %d, but counted only to %d")\
-                                % (i, c.get_heading_enumeration()[0]))
-
+            self.assertEqual(
+                len(c.get_heading_enumeration()),
+                2,
+                (
+                    "two level " "should exist: chapter and section; got instead: {}"
+                ).format(repr(c.get_heading_enumeration())),
+            )
+            self.assertEqual(
+                c.get_heading_enumeration(),
+                [2, i],
+                ("the enumerator " "should have counted to %d, but counted only to %d")
+                % (i, c.get_heading_enumeration()[0]),
+            )
 
     def test_that_objects_with_missing_methods_cause_type_error(self):
         with self.assertRaises(TypeError):
@@ -63,14 +84,15 @@ class test_factories(unittest.TestCase):
             c.register(9)
 
     def test_that_headings_with_none_values_cause_value_error(self):
-        class has_no_level: # heading mock
-            def get_chapter_number(self): return 9
-            def get_level(self): return None
+        class has_no_level:  # heading mock
+            def get_chapter_number(self):
+                return 9
+
+            def get_level(self):
+                return None
+
         c = toc.ChapterNumberEnumerator()
         with self.assertRaises(ValueError):
-            c.register(has_no_level()) # heading with level set
+            c.register(has_no_level())  # heading with level set
         with self.assertRaises(ValueError):
             c.register(h("h1 without chapter", 99))
-
-
-


### PR DESCRIPTION
The Python code is now formatted using the black code formatter. An
appropriate section has been added to README.md to ask contributors to
run black before committing. Black is configured in pyproject.toml.