### PR TITLE
Fix EPUB formula inclusion (#101)

### DIFF
--- a/MAGSBS/master.py
+++ b/MAGSBS/master.py
@@ -100,6 +100,9 @@ files are converted."""
     def _run(self):
         orig_cwd = os.getcwd()
         for root in self.get_roots():
+            # Ensure each conversion step refers to the same directory,
+            # relative paths can be tricky.
+            root = os.path.abspath(root)
             os.chdir(root)
             if self._output_format == pandoc.formats.OutputFormat.Html:
                 conf = config.ConfFactory().get_conf_instance(".")
@@ -113,7 +116,7 @@ files are converted."""
                         with open("inhalt.md", "w", encoding="utf-8") as file:
                             file.write(md_creator.format())
 
-            conv = pandoc.converter.Pandoc(root_path=orig_cwd)
+            conv = pandoc.converter.Pandoc(root_path=root)
             files_to_convert = [
                 os.path.join(dir, f)
                 for dir, _, flist in filesystem.get_markdown_files(".", True)

--- a/MAGSBS/pandoc/output_formats/epub.py
+++ b/MAGSBS/pandoc/output_formats/epub.py
@@ -177,8 +177,8 @@ class EpubConverter(OutputGenerator):
                     try:
                         # this alters the Pandoc document AST -- no return required
                         contentfilter.convert_formulas(
-                            path,
-                            os.path.join(os.path.dirname(entry["path"]), "bilder"),
+                            entry["path"],
+                            "bilder",
                             json_ast,
                         )
                     except errors.MathError as err:
@@ -282,7 +282,7 @@ class EpubConverter(OutputGenerator):
         """Take a string and return a valid filename constructed from the string.
         Uses a whitelist approach: any characters not present in valid_chars are
         removed.
-         
+
         Note: this method may produce invalid filenames such as ``, `.` or `..`
         """
         filename = "".join(


### PR DESCRIPTION
Due to incorrect usage of `contentfilter.convert_formulas` and a wrongly set root path, the formulas were converted to images in the parent directory of the project root and not found by `pandoc`, so they weren't included in the generated EPUB. These have been corrected, so the EPUB should now also include formulas.

Note, that after this change the generated EPUB file is no longer placed in the current working directory of the invocation but in the conversion root (where the `.lecture_meta_data.dcxml` is located) instead.

Closes #101.