### PR TITLE
Fix Pandoc smallcaps styling

### DIFF
--- a/MAGSBS/pandoc/output_formats/epub.py
+++ b/MAGSBS/pandoc/output_formats/epub.py
@@ -17,6 +17,7 @@ from ..formats import execute, ConversionProfile, OutputGenerator
 CSS_TEMPLATE = """/* This defines styles and classes used in the book */
 body { margin: 5%; text-align: justify; font-size: medium; }
 code { font-family: monospace; }
+span.smallcaps { font-variant: small-caps; }
 h1 { text-align: left; font-size: 2em; }
 h2 { text-align: left; font-size: 1.5em; }
 h3 { text-align: left; font-size: 1.17em; }

--- a/MAGSBS/pandoc/output_formats/html.py
+++ b/MAGSBS/pandoc/output_formats/html.py
@@ -25,6 +25,7 @@ $if(date-meta)$
 $endif$
   <title>$if(title-prefix)$$title-prefix$ - $endif$$pagetitle$</title>
   <style type="text/css">
+$styles.html()$
     code {{ white-space: pre; }}
     .underline {{ text-decoration: underline }}
     .annotation {{ border:2px solid #000000; background-color: #FCFCFC; }}
@@ -233,7 +234,11 @@ class HtmlConverter(OutputGenerator):
         json_ast = self.__apply_filters(json_ast, path)
         dirname, filename = os.path.split(path)
         outputf = os.path.splitext(filename)[0] + "." + self.FILE_EXTENSION
-        pandoc_args = ["-s", "--template=%s" % self.template_path]
+        pandoc_args = [
+            "-s",
+            "--template=%s" % self.template_path,
+            "--metadata=document-css:false",
+        ]
         # set title
         title = contentfilter.get_title(json_ast)
         if title:  # if not None

--- a/tests/test_pandoc.py
+++ b/tests/test_pandoc.py
@@ -71,8 +71,23 @@ class test_HTMLConverter(unittest.TestCase):
             self.call_cleanup_on_me.cleanup()
 
     def test_that_css_information_is_in_template(self):
+        self.assertTrue("$styles.html()$" in get_html_converter().template_copy)
         self.assertTrue(".underline" in get_html_converter().template_copy)
         self.assertTrue(".frame" in get_html_converter().template_copy)
+
+    def test_that_pandoc_smallcaps_are_styled_in_html_output(self):
+        with CleverTmpDir():
+            path = os.path.join("k99", "k99.md")
+            os.mkdir(os.path.dirname(path))
+            with open(path, "w", encoding="utf-8") as file:
+                file.write("This is normal text and [Small caps]{.smallcaps}.\n")
+            h = get_html_converter()
+            h.set_profile(pandoc.formats.ConversionProfile.VisuallyImpairedDefault)
+            h.convert([path], cache=mkcache(path))
+            with open(path.replace(".md", ".html"), encoding="utf-8") as f:
+                data = f.read()
+            self.assertTrue('class="smallcaps"' in data)
+            self.assertTrue("font-variant: small-caps" in data)
 
     def test_that_unsupported_formats_are_detected(self):
         with self.assertRaises(NotImplementedError):
@@ -197,6 +212,10 @@ class test_EPUBConverter(unittest.TestCase):
         h = get_epub_converter()
         self.call_cleanup_on_me = h
         self.assertTrue(os.path.exists(h.css_path))
+        with open(h.css_path, encoding="utf-8") as file:
+            css = file.read()
+        self.assertTrue("span.smallcaps" in css)
+        self.assertTrue("font-variant: small-caps" in css)
 
     def test_conentfilter_link_converter(self):
         """ast contains a link: 'target.html#target_id'.


### PR DESCRIPTION
## Summary

Pandoc-native `[Small caps]{.smallcaps}` already generated `<span class="smallcaps">`, but the generated output did not include CSS for rendering `.smallcaps`.

This adds Pandoc's stylesheet extension hook to the HTML template and adds the matching EPUB CSS rule.

## Validation

- Related regression tests pass.
- Manual HTML and EPUB outputs contain both `class="smallcaps"` and `font-variant: small-caps`.

Closes #96.