### PR TITLE
Create Pandoc document cache

### DIFF
--- a/MAGSBS/cache.py
+++ b/MAGSBS/cache.py
@@ -1,0 +1,36 @@
+import copy
+import os
+from typing import Any, Dict, Optional
+
+from .pandoc import contentfilter
+
+PandocAst = Dict[str, Any]
+
+
+class DocumentCache:
+    """Cache Pandoc JSON ASTs by document path."""
+
+    def __init__(self) -> None:
+        self._store: Dict[str, PandocAst] = {}
+
+    @staticmethod
+    def _normalize_path(path: str) -> str:
+        return os.path.abspath(path)
+
+    def add(self, path: str, ast: PandocAst) -> None:
+        self._store[self._normalize_path(path)] = ast
+
+    def get(self, path: str) -> Optional[PandocAst]:
+        return self._store.get(self._normalize_path(path))
+
+    def get_or_load(self, path: str) -> Optional[PandocAst]:
+        normalized_path = self._normalize_path(path)
+        if normalized_path not in self._store:
+            self._store[normalized_path] = contentfilter.file2json_ast(normalized_path)
+        return self.get(normalized_path)
+
+    def get_copy(self, path: str) -> Optional[PandocAst]:
+        ast = self.get_or_load(path)
+        if ast is None:
+            return None
+        return copy.deepcopy(ast)

--- a/MAGSBS/datastructures.py
+++ b/MAGSBS/datastructures.py
@@ -156,14 +156,18 @@ label "Heading" and attributes "{#id .class key=value}".
         APPENDIX = 1
         PREFACE = 2
 
-    def __init__(self, text, level):
+    def __init__(self, text, level, identifier=None, is_numbered=None):
         self.__line_number = None
         # removes attributes from the text
         self.__text, attributes = extract_label_and_attributes(text)
         # detect if heading is numbered
-        self.__is_numbered = detect_is_numbered(attributes)
+        self.__is_numbered = (
+            detect_is_numbered(attributes) if is_numbered is None else is_numbered
+        )
         # id is generated from the parsed text
-        self.__id = gen_id(self.__text, attributes)
+        self.__id = (
+            gen_id(self.__text, attributes) if identifier is None else identifier
+        )
         self.__level = level
         self.__chapter_number = None
         self.__type = Heading.Type.NORMAL

--- a/MAGSBS/master.py
+++ b/MAGSBS/master.py
@@ -6,6 +6,7 @@
 """For documentation about this module, please refer to its classs master."""
 
 import os
+from . import cache
 from . import config
 from .config import MetaInfo
 from . import common
@@ -101,11 +102,12 @@ files are converted."""
             # relative paths can be tricky.
             root = os.path.abspath(root)
             os.chdir(root)
+            document_cache = cache.DocumentCache()
             if self._output_format == pandoc.formats.OutputFormat.Html:
                 conf = config.ConfFactory().get_conf_instance(".")
                 if conf[MetaInfo.GenerateToc]:
                     # create table of contents
-                    c = toc.HeadingIndexer(".")
+                    c = toc.HeadingIndexer(".", document_cache=document_cache)
                     c.walk()
                     if not c.is_empty():
                         index = c.get_index()
@@ -113,7 +115,9 @@ files are converted."""
                         with open("inhalt.md", "w", encoding="utf-8") as file:
                             file.write(md_creator.format())
 
-            conv = pandoc.converter.Pandoc(root_path=root)
+            conv = pandoc.converter.Pandoc(
+                root_path=root, document_cache=document_cache
+            )
             files_to_convert = [
                 os.path.join(dir, f)
                 for dir, _, flist in filesystem.get_markdown_files(".", True)

--- a/MAGSBS/pandoc/converter.py
+++ b/MAGSBS/pandoc/converter.py
@@ -50,7 +50,7 @@ class Pandoc:
 to the output, handles errors and checks for the correct encoding.
 """
 
-    def __init__(self, conf=None, root_path=None):
+    def __init__(self, conf=None, root_path=None, document_cache=None):
         self.converters = ACTIVE_CONVERTERS
         self.__conf = (
             config.ConfFactory().get_conf_instance(os.getcwd()) if not conf else conf
@@ -60,6 +60,7 @@ to the output, handles errors and checks for the correct encoding.
         self.__conv_profile = ConversionProfile.Blind
         self.__output_format = OutputFormat.Html
         self.__root_path = root_path
+        self.__document_cache = document_cache
 
     def get_formatter_for_format(self, format_):
         """Get converter object."""
@@ -121,7 +122,9 @@ to the output, handles errors and checks for the correct encoding.
         converter.set_meta_data(self.__meta_data)
         converter.setup()
         converter.set_profile(self.__conv_profile)
-        converter.convert(files, path=self.__root_path)
+        converter.convert(
+            files, path=self.__root_path, document_cache=self.__document_cache
+        )
 
     def set_conversion_profile(self, profile):
         if not isinstance(profile, ConversionProfile):

--- a/MAGSBS/pandoc/output_formats/epub.py
+++ b/MAGSBS/pandoc/output_formats/epub.py
@@ -1,4 +1,5 @@
 """HTML output format."""
+
 # vim: set expandtab sts=4 ts=4 sw=4:
 # This is free software, licensed under the LGPL v3. See the file "COPYING" for
 # details.
@@ -117,9 +118,10 @@ class EpubConverter(OutputGenerator):
             raise ValueError("path needs to be specified to save epub.")
         if not files:
             return
+        document_cache = kwargs.get("document_cache")
         file_info = EpubConverter.__generate_file_structure(files)
         try:
-            ast = self.__generate_ast(file_info, kwargs["path"])
+            ast = self.__generate_ast(file_info, kwargs["path"], document_cache)
             self.__convert_document(ast, kwargs["path"])
         except errors.MAGSBS_error as err:
             raise err
@@ -167,47 +169,53 @@ class EpubConverter(OutputGenerator):
                 file_info[name].append({"chapter": chapter, "path": file_name})
         return file_info
 
-    def __generate_ast(self, file_info, path):
+    def __generate_ast(self, file_info, path, document_cache=None):
         """reads all files and generate one ast in correct order."""
         ast = {}
         for key in self.LECTURE_ORDER:
             for entry in file_info[key]:
-                with open(entry["path"], "r", encoding="utf-8") as file:
-                    json_ast = contentfilter.load_pandoc_ast(file.read())
-                    try:
-                        # this alters the Pandoc document AST -- no return required
-                        contentfilter.convert_formulas(
-                            entry["path"],
-                            "bilder",
-                            json_ast,
-                        )
-                    except errors.MathError as err:
-                        EpubConverter.__handle_error(path, err)
-                    self.__apply_filters(
+                json_ast = self.__get_json_ast(entry["path"], document_cache)
+                try:
+                    # this alters the Pandoc document AST -- no return required
+                    contentfilter.convert_formulas(
+                        entry["path"],
+                        "bilder",
                         json_ast,
-                        self.CHAPTER_CONTENT_FILTERS,
-                        path,
-                        os.path.dirname(entry["path"]),
                     )
-                    if key == "images":
-                        self.__apply_filters(json_ast, self.IMAGE_CONTENT_FILTERS, path)
-                    elif key == "backmatter":
-                        self.__apply_filters(
-                            json_ast, self.BACKMATTER_CONTENT_FILTERS, path
-                        )
-                    elif key in self.SPECIAL_MD_FILES:
-                        self.__apply_filters(
-                            json_ast, self.SPECIAL_MD_CONTENT_FILTERS, path
-                        )
-                    if ast:
-                        ast["blocks"].extend(json_ast["blocks"])
-                    else:
-                        ast = json_ast
+                except errors.MathError as err:
+                    EpubConverter.__handle_error(path, err)
+                self.__apply_filters(
+                    json_ast,
+                    self.CHAPTER_CONTENT_FILTERS,
+                    path,
+                    os.path.dirname(entry["path"]),
+                )
+                if key == "images":
+                    self.__apply_filters(json_ast, self.IMAGE_CONTENT_FILTERS, path)
+                elif key == "backmatter":
+                    self.__apply_filters(
+                        json_ast, self.BACKMATTER_CONTENT_FILTERS, path
+                    )
+                elif key in self.SPECIAL_MD_FILES:
+                    self.__apply_filters(
+                        json_ast, self.SPECIAL_MD_CONTENT_FILTERS, path
+                    )
+                if ast:
+                    ast["blocks"].extend(json_ast["blocks"])
+                else:
+                    ast = json_ast
         meta_ast = contentfilter.load_pandoc_ast(
             YAML_TEMPLATE.format(**self.get_meta_data())
         )
         ast["meta"] = meta_ast["meta"]
         return ast
+
+    @staticmethod
+    def __get_json_ast(path, document_cache=None):
+        if document_cache is not None:
+            return document_cache.get_copy(path)
+        with open(path, "r", encoding="utf-8") as file:
+            return contentfilter.load_pandoc_ast(file.read())
 
     # pylint: disable=too-many-locals
     def __convert_document(self, json_ast, path):

--- a/MAGSBS/pandoc/output_formats/html.py
+++ b/MAGSBS/pandoc/output_formats/html.py
@@ -174,10 +174,11 @@ class HtmlConverter(OutputGenerator):
         """See super class documentation."""
         from ..converter import Pandoc
 
-        cache, files = Pandoc.get_cache(files)
+        file_cache, files = Pandoc.get_cache(files)
+        document_cache = kwargs.get("document_cache")
         try:
             for file_name in files:
-                self.__convert_document(file_name, cache)
+                self.__convert_document(file_name, file_cache, document_cache)
         except errors.MAGSBS_error as err:
             if not err.path:
                 err.path = file_name
@@ -202,7 +203,7 @@ class HtmlConverter(OutputGenerator):
         raise err from None  # no TB here
 
     # pylint: disable=too-many-locals
-    def __convert_document(self, path, file_cache):
+    def __convert_document(self, path, file_cache, document_cache=None):
         """Convert a document by a given path. It takes a converter which takes
         actual care of the underlying format. The filecache caches the list of
         files in the lecture. The list of files within a lecture is required to
@@ -212,24 +213,40 @@ class HtmlConverter(OutputGenerator):
         # only convert if output file is newer than input file
         if not self.needs_update(path):
             return
-        with open(path, "r", encoding="utf-8") as file:
-            document = file.read()
-        if not document:
-            return  # skip empty documents
+        if document_cache is None:
+            with open(path, "r", encoding="utf-8") as file:
+                document = file.read()
+            if not document:
+                return  # skip empty documents
+            json_ast = None
+        else:
+            document = None
+            json_ast = document_cache.get_copy(path)
+            if not json_ast or not json_ast.get("blocks"):
+                return  # skip empty documents
         if OutputGenerator.IS_CHAPTER.search(os.path.basename(path)):
             try:
+                page_numbers = (
+                    mparser.extract_page_numbers_from_par(
+                        mparser.file2paragraphs(document)
+                    )
+                    if document is not None
+                    else self.__extract_page_numbers_from_ast(json_ast)
+                )
                 nav_start, nav_end = self.generate_page_navigation(
                     path,
                     file_cache,
-                    mparser.extract_page_numbers_from_par(
-                        mparser.file2paragraphs(document)
-                    ),
+                    page_numbers,
                 )
             except errors.FormattingError as e:
                 e.path = path
                 raise e from None
-            document = "{}\n\n{}\n\n{}\n".format(nav_start, document, nav_end)
-        json_ast = contentfilter.load_pandoc_ast(document)
+            if document is not None:
+                document = "{}\n\n{}\n\n{}\n".format(nav_start, document, nav_end)
+            else:
+                self.__add_navigation(json_ast, nav_start, nav_end)
+        if json_ast is None:
+            json_ast = contentfilter.load_pandoc_ast(document)
         json_ast = self.__apply_filters(json_ast, path)
         dirname, filename = os.path.split(path)
         outputf = os.path.splitext(filename)[0] + "." + self.FILE_EXTENSION
@@ -271,6 +288,33 @@ class HtmlConverter(OutputGenerator):
             ],
             stdin=json.dumps(json_ast),
             cwd=dirname,
+        )
+
+    @staticmethod
+    def __extract_page_numbers_from_ast(json_ast):
+        page_numbers = []
+        for block in json_ast.get("blocks", []):
+            if not isinstance(block, dict) or block.get("t") != "Para":
+                continue
+            text = pandocfilters.stringify(block.get("c", []))
+            if not text.startswith("||"):
+                continue
+            try:
+                page_number = mparser.pnum_from_str(text)
+            except ValueError as e:
+                raise errors.FormattingError(
+                    "cannot recognize page number", *e.args
+                ) from None
+            if page_number:
+                page_numbers.append(page_number)
+        return page_numbers
+
+    @staticmethod
+    def __add_navigation(json_ast, nav_start, nav_end):
+        start_ast = contentfilter.load_pandoc_ast(nav_start)
+        end_ast = contentfilter.load_pandoc_ast(nav_end)
+        json_ast["blocks"] = (
+            start_ast.get("blocks", []) + json_ast["blocks"] + end_ast.get("blocks", [])
         )
 
     def __apply_filters(self, json_ast, file_path):
@@ -339,6 +383,7 @@ class HtmlConverter(OutputGenerator):
                 num % conf[config.MetaInfo.PageNumberingGap] == 0
                 for num in pnum
             )
+
         page_numbers = [pnum for pnum in page_numbers if is_between_gaps(pnum.number)]
 
         if page_numbers:
@@ -347,7 +392,8 @@ class HtmlConverter(OutputGenerator):
             navbar[-1] = navbar[-1][:-2]  # strip ", " from last chunk
         navbar = "".join(navbar)
         chapternav = "[{}](../inhalt.{})".format(
-            trans.get_translation("table of contents").title(), self.FILE_EXTENSION,
+            trans.get_translation("table of contents").title(),
+            self.FILE_EXTENSION,
         )
 
         if previous:

--- a/MAGSBS/toc.py
+++ b/MAGSBS/toc.py
@@ -10,6 +10,8 @@ import collections
 import os
 import re
 
+import pandocfilters
+
 from . import config, errors, mparser, filesystem as fs, datastructures
 from . import datastructures
 
@@ -21,15 +23,16 @@ HeadingType = datastructures.Heading.Type
 
 class HeadingIndexer:
     """Walk the file system tree from "dir" and have a look in all files which end on
-.md. Take headings of level 1 or 2 and add it to the index.
+    .md. Take headings of level 1 or 2 and add it to the index.
 
-Format of index: dict of lists: every filename is the key, the list of heading
-[objects] is the value in the OrderedDict()."""
+    Format of index: dict of lists: every filename is the key, the list of heading
+    [objects] is the value in the OrderedDict()."""
 
-    def __init__(self, path):
+    def __init__(self, path, document_cache=None):
         if not os.path.exists(path):
             raise errors.StructuralError("Directory doesn't exist.", path)
         self.__dir = path
+        self.__document_cache = document_cache
         self.__index = collections.OrderedDict()
 
     def is_empty(self):
@@ -59,6 +62,9 @@ By calling the function, the actual index is build."""
     def __retrieve_headings_from(self, path):
         """Retrieve headings from path and annotate them with 'unedited' if the
         file was not edited yet."""
+        if self.__document_cache is not None:
+            return self.__retrieve_headings_from_ast(path)
+
         with open(path, "r", encoding="utf-8") as cnt:
             paragraphs = mparser.file2paragraphs(cnt.read())
         headings = mparser.extract_headings(path, mparser.rm_codeblocks(paragraphs))
@@ -96,6 +102,68 @@ By calling the function, the actual index is build."""
                 )
             )
         return headings
+
+    def __retrieve_headings_from_ast(self, path):
+        """Retrieve headings from a cached Pandoc AST."""
+        json_ast = self.__document_cache.get_or_load(path)
+        if not json_ast:
+            return []
+
+        headings = []
+        for value in self.__header_values_from(json_ast.get("blocks", [])):
+            heading = self.__heading_from_ast(path, value)
+            if (
+                headings
+                and headings[-1].get_text().strip() == heading.get_text().strip()
+            ):
+                continue
+            headings.append(heading)
+
+        if headings and self.__document_has_only_headings(json_ast):
+            conf = config.ConfFactory().get_conf_instance(path)
+            trans = config.Translate()
+            trans.set_language(conf[MetaInfo.Language])
+            for heading in headings:
+                heading.set_text(
+                    "{} ({})".format(
+                        heading.get_text(), trans.get_translation("not edited")
+                    )
+                )
+        return headings
+
+    @classmethod
+    def __header_values_from(cls, value):
+        if isinstance(value, dict):
+            if value.get("t") == "Header" and "c" in value:
+                yield value["c"]
+                return
+            yield from cls.__header_values_from(value.get("c"))
+        elif isinstance(value, list):
+            for item in value:
+                yield from cls.__header_values_from(item)
+
+    @staticmethod
+    def __heading_from_ast(path, value):
+        level = value[0]
+        attributes = value[1] if len(value) > 1 else ["", [], []]
+        inlines = value[2] if len(value) > 2 else []
+        identifier = attributes[0] if attributes else None
+        classes = attributes[1] if len(attributes) > 1 else []
+        heading = datastructures.Heading(
+            pandocfilters.stringify(inlines),
+            level,
+            identifier=identifier,
+            is_numbered="unnumbered" not in classes,
+        )
+        heading.set_chapter_number(datastructures.extract_chapter_number(path))
+        return heading
+
+    @staticmethod
+    def __document_has_only_headings(json_ast):
+        blocks = json_ast.get("blocks", [])
+        return bool(blocks) and all(
+            isinstance(block, dict) and block.get("t") == "Header" for block in blocks
+        )
 
     def get_index(self):
         tmp = collections.OrderedDict()

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,34 @@
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+from MAGSBS.cache import DocumentCache
+
+
+class TestDocumentCache(unittest.TestCase):
+    def test_get_or_load_loads_document_only_once(self):
+        ast = {"blocks": [], "meta": {}}
+        with tempfile.TemporaryDirectory() as directory:
+            path = os.path.join(directory, "k01.md")
+            with mock.patch(
+                "MAGSBS.cache.contentfilter.file2json_ast", return_value=ast
+            ) as file2json_ast:
+                cache = DocumentCache()
+
+                self.assertIs(cache.get_or_load(path), ast)
+                self.assertIs(cache.get_or_load(path), ast)
+
+                file2json_ast.assert_called_once_with(os.path.abspath(path))
+
+    def test_get_copy_does_not_mutate_cached_ast(self):
+        ast = {"blocks": [{"t": "Para", "c": []}], "meta": {}}
+        with tempfile.TemporaryDirectory() as directory:
+            path = os.path.join(directory, "k01.md")
+            cache = DocumentCache()
+            cache.add(path, ast)
+
+            ast_copy = cache.get_copy(path)
+            ast_copy["blocks"].append({"t": "Para", "c": []})
+
+            self.assertEqual(1, len(cache.get(path)["blocks"]))

--- a/tests/test_toc.py
+++ b/tests/test_toc.py
@@ -4,6 +4,7 @@ import shutil
 import tempfile
 import unittest
 import MAGSBS.datastructures
+from MAGSBS.cache import DocumentCache
 from MAGSBS import config
 import MAGSBS.toc as toc
 
@@ -139,3 +140,125 @@ class TestHeadingIndexer(unittest.TestCase):
 
         self.assertIn("Title", output)
         self.assertNotIn("Yields erroneously a heading entry", output)
+
+    def test_that_cached_pandoc_ast_is_used_for_toc(self):
+        self.write_conf()
+        os.mkdir("k01")
+        path = os.path.join("k01", "k01.md")
+        with open(path, "w", encoding="utf-8") as file:
+            file.write("# Different title in file\n")
+        document_cache = DocumentCache()
+        document_cache.add(
+            path,
+            {
+                "blocks": [
+                    {
+                        "t": "Header",
+                        "c": [
+                            1,
+                            ["cached-title", [], []],
+                            [
+                                {"t": "Str", "c": "Cached"},
+                                {"t": "Space"},
+                                {"t": "Str", "c": "Title"},
+                            ],
+                        ],
+                    }
+                ],
+                "meta": {},
+            },
+        )
+
+        indexer = toc.HeadingIndexer(".", document_cache=document_cache)
+        indexer.walk()
+        output = toc.TocFormatter(indexer.get_index(), ".").format()
+
+        self.assertIn("Cached Title", output)
+        self.assertIn("#cached-title", output)
+        self.assertNotIn("Different title in file", output)
+
+    def test_that_unnumbered_cached_headings_are_omitted_from_toc(self):
+        self.write_conf()
+        os.mkdir("k01")
+        path = os.path.join("k01", "k01.md")
+        with open(path, "w", encoding="utf-8") as file:
+            file.write("# Visible\n\n# Hidden {.unnumbered}\n")
+        document_cache = DocumentCache()
+        document_cache.add(
+            path,
+            {
+                "blocks": [
+                    {
+                        "t": "Header",
+                        "c": [
+                            1,
+                            ["visible", [], []],
+                            [{"t": "Str", "c": "Visible"}],
+                        ],
+                    },
+                    {
+                        "t": "Header",
+                        "c": [
+                            1,
+                            ["hidden", ["unnumbered"], []],
+                            [{"t": "Str", "c": "Hidden"}],
+                        ],
+                    },
+                ],
+                "meta": {},
+            },
+        )
+
+        indexer = toc.HeadingIndexer(".", document_cache=document_cache)
+        indexer.walk()
+        output = toc.TocFormatter(indexer.get_index(), ".").format()
+
+        self.assertIn("Visible", output)
+        self.assertNotIn("Hidden", output)
+
+    def test_that_duplicate_cached_headings_are_omitted_from_toc(self):
+        self.write_conf()
+        os.mkdir("k01")
+        path = os.path.join("k01", "k01.md")
+        with open(path, "w", encoding="utf-8") as file:
+            file.write("# Title {-}\n\nTitle\n=====\n")
+        document_cache = DocumentCache()
+        document_cache.add(
+            path,
+            {
+                "blocks": [
+                    {
+                        "t": "Header",
+                        "c": [
+                            1,
+                            ["title", ["unnumbered"], []],
+                            [{"t": "Str", "c": "Title"}],
+                        ],
+                    },
+                    {
+                        "t": "Header",
+                        "c": [
+                            1,
+                            ["title-1", [], []],
+                            [{"t": "Str", "c": "Title"}],
+                        ],
+                    },
+                    {
+                        "t": "Header",
+                        "c": [
+                            2,
+                            ["introduction", [], []],
+                            [{"t": "Str", "c": "Introduction"}],
+                        ],
+                    },
+                ],
+                "meta": {},
+            },
+        )
+
+        indexer = toc.HeadingIndexer(".", document_cache=document_cache)
+        indexer.walk()
+        output = toc.TocFormatter(indexer.get_index(), ".").format()
+
+        self.assertNotIn("Title", output)
+        self.assertIn("Introduction", output)


### PR DESCRIPTION
## Summary

Add a shared `DocumentCache` for Pandoc JSON ASTs and reuse it during TOC generation and conversion.

## Changes

- add `MAGSBS.cache.DocumentCache`
- pass the cache through `Master` and `Pandoc`
- let `HeadingIndexer` read headings from cached Pandoc ASTs
- reuse cached ASTs in HTML and EPUB conversion
- add regression tests for cache loading and TOC behavior

## Verification

- focused unit tests pass
- `matuc conv .` on one paper to ensure the stability of workflow

Closes #109.