### PR TITLE
Fix Python 3.11 test suite failures

### DIFF
--- a/MAGSBS/config.py
+++ b/MAGSBS/config.py
@@ -11,6 +11,7 @@ MAGSBS-specific extensions.
 
 import enum
 import datetime
+import builtins
 import os
 import re
 import sys
@@ -24,6 +25,11 @@ from .errors import ConfigurationError
 from . import roman
 
 VERSION = packaging.version.Version("0.9")
+
+
+def _(message):
+    return getattr(builtins, "_", lambda text: text)(message)
+
 
 ## default values
 CONF_FILE_NAME = ".lecture_meta_data.dcxml"
@@ -171,7 +177,7 @@ instead.
                 self[MetaInfo.Editor] = editor
         self[MetaInfo.SemesterOfEdit] = get_semester()  # guess current semester
         self.__changed = False
-        self.__version = version
+        self.__version = packaging.version.Version(str(version))
 
     def write(self):
         """Write back configuration, if it was changed."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,15 +2,15 @@
 import unittest
 from unittest.mock import patch
 
-import distutils.version
 import os
+import packaging.version
 import shutil
 import tempfile
 from MAGSBS import config, common, errors
 from MAGSBS.config import MetaInfo
 
 conf = lambda conf, version=str(config.VERSION): config.LectureMetaData(
-    conf, distutils.version.StrictVersion(version)
+    conf, packaging.version.Version(version)
 )
 
 

--- a/tests/test_locale.py
+++ b/tests/test_locale.py
@@ -16,7 +16,7 @@ def fake_mo(actual_path, desired=None):
 
 fake_usr_local = lambda x: fake_mo(x, desired="/usr/share/locale")
 fake_c_program_files = lambda x: fake_mo(x, desired="C:\\ProgramData")
-fake_none = lambda x: fake_mo(x, ".")
+fake_none = lambda x: [(x, (), ())]
 
 
 def normalise_path(path):
@@ -48,5 +48,6 @@ class test_locale(unittest.TestCase):
         # Code sammeln, assert* ausführen
 
     @patch("os.walk", fake_none)
+    @patch.dict(os.environ, {}, clear=True)
     def test_install_locale_returns_none(self):
         self.assertEqual(_get_localedir(), None)


### PR DESCRIPTION
## Summary

Fix Python 3.11 full-suite failures in config version handling and locale test isolation.

## Verification

- `python -m unittest discover -s tests -p 'test_config.py'`
- `python -m unittest discover -s tests -p 'test_locale.py'`
- `python -m unittest discover -s tests`

Closes #112.
