### PR TITLE
Replace Pandoc HTML template with header injection

### DIFF
--- a/MAGSBS/pandoc/output_formats/html.py
+++ b/MAGSBS/pandoc/output_formats/html.py
@@ -15,17 +15,9 @@ from ..formats import execute, remove_temp, ConversionProfile, OutputGenerator
 
 
 # pylint: disable=line-too-long
-HTML_TEMPLATE = """<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml"$if(lang)$ lang="$lang$" xml:lang="$lang$"$endif$>
-<head>
-  <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+HTML_HEADER_TEMPLATE = """
   <meta name="author" content="{SourceAuthor}" />
-$if(date-meta)$
-  <meta name="date" content="$date-meta$" />
-$endif$
-  <title>$if(title-prefix)$$title-prefix$ - $endif$$pagetitle$</title>
   <style type="text/css">
-$styles.html()$
     code {{ white-space: pre; }}
     .underline {{ text-decoration: underline }}
     .annotation {{ border:2px solid #000000; background-color: #FCFCFC; }}
@@ -40,17 +32,7 @@ $styles.html()$
     div.frame span.title:after {{ content: "\\A"; white-space:pre; }}
     div.box span.title:before {{ content: "\\A{title}: "; white-space:pre; }}
     div.box span.title:after {{ content: "\\A"; white-space:pre; }}
-
-$if(highlighting-css)$
-$highlighting-css$
-$endif$
   </style>
-$if(math)$
-  $math$
-$endif$
-$for(header-includes)$
-  $header-includes$
-$endfor$
   <!-- agsbs-specific -->
   <meta name='Einrichtung' content='{Institution}' />
   <meta href='Arbeitsgruppe' content='{WorkingGroup}' />
@@ -58,22 +40,6 @@ $endfor$
   <meta name='Lehrgebiet' content='{LectureTitle}' />
   <meta name='Semester der Bearbeitung' content='{SemesterOfEdit}' />
   <meta name='Bearbeiter' content='{Editor}' />
-</head>
-<body lang="{Language}">
-$for(include-before)$
-$include-before$
-$endfor$
-$if(toc)$
-<div id="$idprefix$TOC">
-$toc$
-</div>
-$endif$
-$body$
-$for(include-after)$
-$include-after$
-$endfor$
-</body>
-</html>
 """
 
 
@@ -95,21 +61,21 @@ class HtmlConverter(OutputGenerator):
             )
 
         super().__init__(meta, language)
-        self.template_path = None
-        self.template_copy = HTML_TEMPLATE[:]  # full copy
+        self.header_path = None
+        self.header_copy = HTML_HEADER_TEMPLATE[:]  # full copy
 
     def setup(self):
-        """Set up the HtmlConverter. Prepare the template for later use."""
-        self.template_path = tempfile.mktemp() + ".html"
-        self.template_copy = self.get_template()
-        with open(self.template_path, "w", encoding="utf-8") as file:
-            file.write(self.template_copy)
+        """Set up the HtmlConverter. Prepare the header include for later use."""
+        self.header_path = tempfile.mktemp() + ".html"
+        self.header_copy = self.get_header()
+        with open(self.header_path, "w", encoding="utf-8") as file:
+            file.write(self.header_copy)
 
-    def get_template(self):
-        """Construct template."""
+    def get_header(self):
+        """Construct Pandoc header include."""
         start_with_caps = lambda content: content[0].upper() + content[1:]
-        data = HTML_TEMPLATE[:]
-        meta = self.get_meta_data()
+        data = HTML_HEADER_TEMPLATE[:]
+        meta = dict(self.get_meta_data())
         if "title" in meta:
             meta.pop("title")  # title should not be replaced
 
@@ -167,7 +133,7 @@ class HtmlConverter(OutputGenerator):
             )
 
     def set_meta_data(self, meta):
-        """Overwrite parent settr to re-generate template generation."""
+        """Overwrite parent setter to re-generate the header include."""
         super().set_meta_data(meta)
         self.setup()
 
@@ -236,13 +202,15 @@ class HtmlConverter(OutputGenerator):
         outputf = os.path.splitext(filename)[0] + "." + self.FILE_EXTENSION
         pandoc_args = [
             "-s",
-            "--template=%s" % self.template_path,
+            "--include-in-header=%s" % self.header_path,
             "--metadata=document-css:false",
+            "-V",
+            "lang:" + self.get_meta_data()["Language"],
         ]
         # set title
         title = contentfilter.get_title(json_ast)
         if title:  # if not None
-            pandoc_args += ["-V", "pagetitle:" + title, "-V", "title:" + title]
+            pandoc_args += ["-V", "pagetitle:" + title]
         # instruct pandoc to enumerate headings
         try:
             from ...config import MetaInfo
@@ -366,7 +334,7 @@ class HtmlConverter(OutputGenerator):
         return (nav_start, nav_end)
 
     def cleanup(self):
-        remove_temp(self.template_path)
+        remove_temp(self.header_path)
 
     def needs_update(self, path):
         # if file exists and input is newer than output, needs to be converted

--- a/tests/test_pandoc.py
+++ b/tests/test_pandoc.py
@@ -20,10 +20,8 @@ META_DATA = {
 }
 
 
-def get_html_converter(meta_data=META_DATA, template=None):
+def get_html_converter(meta_data=META_DATA):
     h = pandoc.output_formats.html.HtmlConverter(meta_data, language="de")
-    if template:
-        h.template_copy = template
     h.setup()
     return h
 
@@ -70,10 +68,12 @@ class test_HTMLConverter(unittest.TestCase):
         if self.call_cleanup_on_me:
             self.call_cleanup_on_me.cleanup()
 
-    def test_that_css_information_is_in_template(self):
-        self.assertTrue("$styles.html()$" in get_html_converter().template_copy)
-        self.assertTrue(".underline" in get_html_converter().template_copy)
-        self.assertTrue(".frame" in get_html_converter().template_copy)
+    def test_that_agsbs_information_is_in_header_include(self):
+        header = get_html_converter().header_copy
+        self.assertTrue("$styles.html()$" not in header)
+        self.assertTrue(".underline" in header)
+        self.assertTrue(".frame" in header)
+        self.assertTrue("Einrichtung" in header)
 
     def test_that_pandoc_smallcaps_are_styled_in_html_output(self):
         with CleverTmpDir():
@@ -89,6 +89,20 @@ class test_HTMLConverter(unittest.TestCase):
             self.assertTrue('class="smallcaps"' in data)
             self.assertTrue("font-variant: small-caps" in data)
 
+    def test_that_agsbs_header_include_is_used_in_html_output(self):
+        with CleverTmpDir():
+            path = os.path.join("k99", "k99.md")
+            os.mkdir(os.path.dirname(path))
+            with open(path, "w", encoding="utf-8") as file:
+                file.write("Body\n")
+            h = get_html_converter()
+            h.convert([path], cache=mkcache(path))
+            with open(path.replace(".md", ".html"), encoding="utf-8") as f:
+                data = f.read()
+            self.assertTrue('<meta name="generator" content="pandoc" />' in data)
+            self.assertTrue("<meta name='Einrichtung' content='unique3' />" in data)
+            self.assertTrue(".annotation" in data)
+
     def test_that_unsupported_formats_are_detected(self):
         with self.assertRaises(NotImplementedError):
             pandoc.converter.Pandoc().get_formatter_for_format("mp4")
@@ -97,19 +111,19 @@ class test_HTMLConverter(unittest.TestCase):
         h = pandoc.converter.Pandoc().get_formatter_for_format("html")
         self.call_cleanup_on_me = h
         h.set_meta_data(META_DATA)
-        data = h.get_template()
+        data = h.get_header()
         for key, value in META_DATA.items():
-            if key == "title" or key == "language" or key == "path":
+            if key in ("title", "Language", "path"):
                 continue  # those don't need to be included
             self.assertTrue(
                 value in data,
-                "%s (key=%s) not found in the template\n%s" % (value, key, str(data)),
+                "%s (key=%s) not found in the header\n%s" % (value, key, str(data)),
             )
 
-    def test_that_setup_writes_template(self):
+    def test_that_setup_writes_header_include(self):
         h = get_html_converter()
         self.call_cleanup_on_me = h
-        self.assertTrue(os.path.exists(h.template_path))
+        self.assertTrue(os.path.exists(h.header_path))
 
     def test_title_is_contained_in_document(self):
         with CleverTmpDir():
@@ -122,13 +136,15 @@ class test_HTMLConverter(unittest.TestCase):
             with open(path.replace(".md", ".html")) as f:
                 data = f.read()
             self.assertTrue("<title>It works!</title>" in data)
+            self.assertTrue("<h1" in data and "It works!" in data)
+            self.assertFalse('<header id="title-block-header">' in data)
 
     def test_that_missing_key_raises_conf_error(self):
         meta = dict(META_DATA)
         meta.pop("SourceAuthor")
         self.assertRaises(errors.ConfigurationError, get_html_converter, meta)
 
-    def test_that_language_is_set_in_body(self):
+    def test_that_language_is_set_on_document(self):
         meta = META_DATA.copy()
         meta["Language"] = "fr"
         with CleverTmpDir():
@@ -140,10 +156,9 @@ class test_HTMLConverter(unittest.TestCase):
             h.convert([path], cache=mkcache(path))
             with open(path.replace(".md", ".html")) as f:
                 data = f.read()
-            bodypos = data.find("<body")
             self.assertTrue(
-                '<body lang="fr"' in data or "<body lang='fr'" in data,
-                repr(data[bodypos : bodypos + 250]),
+                'lang="fr"' in data and 'xml:lang="fr"' in data,
+                repr(data[:250]),
             )
 
     def test_conentfilter_link_converter(self):


### PR DESCRIPTION
## Summary

Replace the embedded custom Pandoc HTML template with Pandoc's default template plus an AGSBS-specific `--include-in-header` snippet.

## Validation

- `python -m unittest discover -s tests -p test_pandoc.py`
- `python -m py_compile MAGSBS/pandoc/output_formats/html.py tests/test_pandoc.py`

Closes #114.